### PR TITLE
remove init will call sequence(map) twice

### DIFF
--- a/Genome/Source/MappableObject.swift
+++ b/Genome/Source/MappableObject.swift
@@ -38,7 +38,6 @@ extension MappableObject {
     public init(js: Json, context: Context = EmptyJson) throws {
         let map = Map(json: js, context: context)
         try self.init(map: map)
-        try sequence(map)
     }
     
     // JsonConvertibleTypeConformance
@@ -77,7 +76,6 @@ public class Object : MappableObject {
     public static func newInstance(json: Json, context: Context) throws -> Self {
         let map = Map(json: json, context: context)
         let new = try self.init(map: map)
-        try new.sequence(map)
         return new
     }
 }


### PR DESCRIPTION
It seems that the init method will call sequence(map) twice(one from self.init(map)).

If I do this, which array has 2 object
```Swift
func sequence(map: Map) throws -> Void {
  let array = try <~map[“array”]
    self.list.appendContentOf(array)
}
```
after init, my list will have 4 object

This happen when I integrated with Realm Object, the type is List<XXX>