### PR TITLE
Fix Carthage integration, part 2 :)

### DIFF
--- a/Genome/Info.plist
+++ b/Genome/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
A small but required change for the Carthage integration to work. The Bundle Package Type has to be Framework (which also obviously makes sense anyway). If not Carthage fails to build the dependencies (see https://github.com/Carthage/Carthage/blob/master/Source/CarthageKit/Xcode.swift#L544).

Without the change carthage emits the following error:
```
...
*** Building scheme "Genome-iOS" in Genome.xcworkspace
Failed to read file or folder at /Users/mauricio/Library/Developer/Xcode/DerivedData/Genome-azjcrrllulcaiqguleqcwwejjsfs/Build/Products/Release-iphoneos/Genome.framework
```