### PR TITLE
Making tests crash safe

### DIFF
--- a/Genome.xcodeproj/project.pbxproj
+++ b/Genome.xcodeproj/project.pbxproj
@@ -1,1898 +1,1441 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      OBJ_1 = {
-         isa = "PBXProject";
-         attributes = {
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = OBJ_2;
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "English";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en",
-         );
-         mainGroup = OBJ_5;
-         productRefGroup = OBJ_70;
-         projectDirPath = ".";
-         targets = (
-            OBJ_79,
-            OBJ_87,
-            OBJ_95,
-            OBJ_127,
-            OBJ_144,
-            OBJ_162,
-            OBJ_179,
-            OBJ_197,
-         );
-      };
-      OBJ_10 = {
-         isa = "PBXFileReference";
-         path = "PathIndexable.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_100 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_15;
-      };
-      OBJ_101 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_17;
-      };
-      OBJ_102 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_18;
-      };
-      OBJ_103 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_19;
-      };
-      OBJ_104 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_20;
-      };
-      OBJ_105 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_21;
-      };
-      OBJ_106 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_22;
-      };
-      OBJ_107 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_23;
-      };
-      OBJ_108 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_24;
-      };
-      OBJ_109 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_25;
-      };
-      OBJ_11 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_12,
-            OBJ_13,
-         );
-         name = "Polymorphic";
-         path = "Packages/Polymorphic-1.0.0/Sources";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_110 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_26;
-      };
-      OBJ_111 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_28;
-      };
-      OBJ_112 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_29;
-      };
-      OBJ_113 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_30;
-      };
-      OBJ_114 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_31;
-      };
-      OBJ_115 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_32;
-      };
-      OBJ_116 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_33;
-      };
-      OBJ_117 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_34;
-      };
-      OBJ_118 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_35;
-      };
-      OBJ_119 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_37;
-      };
-      OBJ_12 = {
-         isa = "PBXFileReference";
-         path = "Polymorphic.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_120 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_39;
-      };
-      OBJ_121 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_41;
-      };
-      OBJ_122 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            OBJ_123,
-            OBJ_124,
-         );
-      };
-      OBJ_123 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_71;
-      };
-      OBJ_124 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_72;
-      };
-      OBJ_125 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_79;
-      };
-      OBJ_126 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_87;
-      };
-      OBJ_127 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_128;
-         buildPhases = (
-            OBJ_131,
-            OBJ_137,
-         );
-         dependencies = (
-            OBJ_141,
-            OBJ_142,
-            OBJ_143,
-         );
-         name = "Genome";
-         productName = "Genome";
-         productReference = OBJ_74;
-         productType = "com.apple.product-type.framework";
-      };
-      OBJ_128 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_129,
-            OBJ_130,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_129 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/Genome_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Genome";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "Genome";
-         };
-         name = "Debug";
-      };
-      OBJ_13 = {
-         isa = "PBXFileReference";
-         path = "String+Polymorphic.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_130 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/Genome_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Genome";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "Genome";
-         };
-         name = "Release";
-      };
-      OBJ_131 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_132,
-            OBJ_133,
-            OBJ_134,
-            OBJ_135,
-            OBJ_136,
-         );
-      };
-      OBJ_132 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_43;
-      };
-      OBJ_133 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_45;
-      };
-      OBJ_134 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_46;
-      };
-      OBJ_135 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_47;
-      };
-      OBJ_136 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_48;
-      };
-      OBJ_137 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            OBJ_138,
-            OBJ_139,
-            OBJ_140,
-         );
-      };
-      OBJ_138 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_71;
-      };
-      OBJ_139 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_72;
-      };
-      OBJ_14 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_15,
-            OBJ_16,
-            OBJ_27,
-            OBJ_36,
-            OBJ_38,
-            OBJ_40,
-         );
-         name = "Node";
-         path = "Packages/Node-1.0.1/Sources/Node";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_140 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_73;
-      };
-      OBJ_141 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_79;
-      };
-      OBJ_142 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_87;
-      };
-      OBJ_143 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_95;
-      };
-      OBJ_144 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_145;
-         buildPhases = (
-            OBJ_148,
-            OBJ_151,
-         );
-         dependencies = (
-            OBJ_157,
-            OBJ_158,
-            OBJ_159,
-            OBJ_160,
-            OBJ_161,
-         );
-         name = "GenomeCoreData";
-         productName = "GenomeCoreData";
-         productReference = OBJ_75;
-         productType = "com.apple.product-type.framework";
-      };
-      OBJ_145 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_146,
-            OBJ_147,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_146 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeCoreData_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "GenomeCoreData";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeCoreData";
-         };
-         name = "Debug";
-      };
-      OBJ_147 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeCoreData_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "GenomeCoreData";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeCoreData";
-         };
-         name = "Release";
-      };
-      OBJ_148 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_149,
-            OBJ_150,
-         );
-      };
-      OBJ_149 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_50;
-      };
-      OBJ_15 = {
-         isa = "PBXFileReference";
-         path = "NodeBacked.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_150 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_51;
-      };
-      OBJ_151 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            OBJ_152,
-            OBJ_153,
-            OBJ_154,
-            OBJ_155,
-            OBJ_156,
-         );
-      };
-      OBJ_152 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_71;
-      };
-      OBJ_153 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_72;
-      };
-      OBJ_154 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_73;
-      };
-      OBJ_155 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_74;
-      };
-      OBJ_156 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_76;
-      };
-      OBJ_157 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_79;
-      };
-      OBJ_158 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_87;
-      };
-      OBJ_159 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_95;
-      };
-      OBJ_16 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_17,
-            OBJ_18,
-            OBJ_19,
-            OBJ_20,
-            OBJ_21,
-            OBJ_22,
-            OBJ_23,
-            OBJ_24,
-            OBJ_25,
-            OBJ_26,
-         );
-         path = "Convertible";
-         sourceTree = "<group>";
-      };
-      OBJ_160 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_127;
-      };
-      OBJ_161 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_162;
-      };
-      OBJ_162 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_163;
-         buildPhases = (
-            OBJ_166,
-            OBJ_170,
-         );
-         dependencies = (
-            OBJ_175,
-            OBJ_176,
-            OBJ_177,
-            OBJ_178,
-         );
-         name = "GenomeFoundation";
-         productName = "GenomeFoundation";
-         productReference = OBJ_76;
-         productType = "com.apple.product-type.framework";
-      };
-      OBJ_163 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_164,
-            OBJ_165,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_164 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeFoundation_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "GenomeFoundation";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeFoundation";
-         };
-         name = "Debug";
-      };
-      OBJ_165 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeFoundation_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "GenomeFoundation";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeFoundation";
-         };
-         name = "Release";
-      };
-      OBJ_166 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_167,
-            OBJ_168,
-            OBJ_169,
-         );
-      };
-      OBJ_167 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_53;
-      };
-      OBJ_168 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_54;
-      };
-      OBJ_169 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_55;
-      };
-      OBJ_17 = {
-         isa = "PBXFileReference";
-         path = "Bool+Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_170 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            OBJ_171,
-            OBJ_172,
-            OBJ_173,
-            OBJ_174,
-         );
-      };
-      OBJ_171 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_71;
-      };
-      OBJ_172 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_72;
-      };
-      OBJ_173 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_73;
-      };
-      OBJ_174 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_74;
-      };
-      OBJ_175 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_79;
-      };
-      OBJ_176 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_87;
-      };
-      OBJ_177 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_95;
-      };
-      OBJ_178 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_127;
-      };
-      OBJ_179 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_180;
-         buildPhases = (
-            OBJ_183,
-            OBJ_186,
-         );
-         dependencies = (
-            OBJ_192,
-            OBJ_193,
-            OBJ_194,
-            OBJ_195,
-            OBJ_196,
-         );
-         name = "GenomeFoundationTests";
-         productName = "GenomeFoundationTests";
-         productReference = OBJ_77;
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      OBJ_18 = {
-         isa = "PBXFileReference";
-         path = "Context.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_180 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_181,
-            OBJ_182,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_181 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeFoundationTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "@loader_path/../Frameworks",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeFoundationTests";
-         };
-         name = "Debug";
-      };
-      OBJ_182 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeFoundationTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "@loader_path/../Frameworks",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeFoundationTests";
-         };
-         name = "Release";
-      };
-      OBJ_183 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_184,
-            OBJ_185,
-         );
-      };
-      OBJ_184 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_58;
-      };
-      OBJ_185 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_59;
-      };
-      OBJ_186 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            OBJ_187,
-            OBJ_188,
-            OBJ_189,
-            OBJ_190,
-            OBJ_191,
-         );
-      };
-      OBJ_187 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_71;
-      };
-      OBJ_188 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_72;
-      };
-      OBJ_189 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_73;
-      };
-      OBJ_19 = {
-         isa = "PBXFileReference";
-         path = "Convertible+Init.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_190 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_74;
-      };
-      OBJ_191 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_76;
-      };
-      OBJ_192 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_79;
-      };
-      OBJ_193 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_87;
-      };
-      OBJ_194 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_95;
-      };
-      OBJ_195 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_127;
-      };
-      OBJ_196 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_162;
-      };
-      OBJ_197 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_198;
-         buildPhases = (
-            OBJ_201,
-            OBJ_210,
-         );
-         dependencies = (
-            OBJ_215,
-            OBJ_216,
-            OBJ_217,
-            OBJ_218,
-         );
-         name = "GenomeTests";
-         productName = "GenomeTests";
-         productReference = OBJ_78;
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      OBJ_198 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_199,
-            OBJ_200,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_199 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "@loader_path/../Frameworks",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeTests";
-         };
-         name = "Debug";
-      };
-      OBJ_2 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_3,
-            OBJ_4,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_20 = {
-         isa = "PBXFileReference";
-         path = "Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_200 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/GenomeTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "@loader_path/../Frameworks",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "GenomeTests";
-         };
-         name = "Release";
-      };
-      OBJ_201 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_202,
-            OBJ_203,
-            OBJ_204,
-            OBJ_205,
-            OBJ_206,
-            OBJ_207,
-            OBJ_208,
-            OBJ_209,
-         );
-      };
-      OBJ_202 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_61;
-      };
-      OBJ_203 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_62;
-      };
-      OBJ_204 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_63;
-      };
-      OBJ_205 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_64;
-      };
-      OBJ_206 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_65;
-      };
-      OBJ_207 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_66;
-      };
-      OBJ_208 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_67;
-      };
-      OBJ_209 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_68;
-      };
-      OBJ_21 = {
-         isa = "PBXFileReference";
-         path = "FloatingPoint+Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_210 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            OBJ_211,
-            OBJ_212,
-            OBJ_213,
-            OBJ_214,
-         );
-      };
-      OBJ_211 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_71;
-      };
-      OBJ_212 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_72;
-      };
-      OBJ_213 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_73;
-      };
-      OBJ_214 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_74;
-      };
-      OBJ_215 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_79;
-      };
-      OBJ_216 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_87;
-      };
-      OBJ_217 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_95;
-      };
-      OBJ_218 = {
-         isa = "PBXTargetDependency";
-         target = OBJ_127;
-      };
-      OBJ_22 = {
-         isa = "PBXFileReference";
-         path = "Integer+Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_23 = {
-         isa = "PBXFileReference";
-         path = "Node+Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_24 = {
-         isa = "PBXFileReference";
-         path = "Sequence+Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_25 = {
-         isa = "PBXFileReference";
-         path = "String+Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_26 = {
-         isa = "PBXFileReference";
-         path = "UnsignedInteger+Convertible.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_27 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_28,
-            OBJ_29,
-            OBJ_30,
-            OBJ_31,
-            OBJ_32,
-            OBJ_33,
-            OBJ_34,
-            OBJ_35,
-         );
-         path = "Core";
-         sourceTree = "<group>";
-      };
-      OBJ_28 = {
-         isa = "PBXFileReference";
-         path = "Node+Accessors.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_29 = {
-         isa = "PBXFileReference";
-         path = "Node+Equatable.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_3 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-            MACOSX_DEPLOYMENT_TARGET = 10.9;
-            TVOS_DEPLOYMENT_TARGET = 9.0;
-            WATCHOS_DEPLOYMENT_TARGET = 2.0;
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode",
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      OBJ_30 = {
-         isa = "PBXFileReference";
-         path = "Node+Exports.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_31 = {
-         isa = "PBXFileReference";
-         path = "Node+Init.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_32 = {
-         isa = "PBXFileReference";
-         path = "Node+Literals.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_33 = {
-         isa = "PBXFileReference";
-         path = "Node+PathIndexable.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_34 = {
-         isa = "PBXFileReference";
-         path = "Node+Polymorphic.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_35 = {
-         isa = "PBXFileReference";
-         path = "Node.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_36 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_37,
-         );
-         path = "Extract";
-         sourceTree = "<group>";
-      };
-      OBJ_37 = {
-         isa = "PBXFileReference";
-         path = "Node+Extract.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_38 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_39,
-         );
-         path = "Number";
-         sourceTree = "<group>";
-      };
-      OBJ_39 = {
-         isa = "PBXFileReference";
-         path = "Number.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_4 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-            MACOSX_DEPLOYMENT_TARGET = 10.9;
-            TVOS_DEPLOYMENT_TARGET = 9.0;
-            WATCHOS_DEPLOYMENT_TARGET = 2.0;
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode",
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-O";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      OBJ_40 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_41,
-         );
-         path = "Utilities";
-         sourceTree = "<group>";
-      };
-      OBJ_41 = {
-         isa = "PBXFileReference";
-         path = "Errors.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_42 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_43,
-            OBJ_44,
-         );
-         name = "Genome";
-         path = "Sources/Genome";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_43 = {
-         isa = "PBXFileReference";
-         path = "Genome+Exports.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_44 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_45,
-            OBJ_46,
-            OBJ_47,
-            OBJ_48,
-         );
-         path = "Mapping";
-         sourceTree = "<group>";
-      };
-      OBJ_45 = {
-         isa = "PBXFileReference";
-         path = "Map.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_46 = {
-         isa = "PBXFileReference";
-         path = "MappableObject.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_47 = {
-         isa = "PBXFileReference";
-         path = "StandardOperators.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_48 = {
-         isa = "PBXFileReference";
-         path = "Transformers.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_49 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_50,
-            OBJ_51,
-         );
-         name = "GenomeCoreData";
-         path = "Sources/GenomeCoreData";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_5 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_6,
-            OBJ_7,
-            OBJ_56,
-            OBJ_69,
-            OBJ_70,
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      OBJ_50 = {
-         isa = "PBXFileReference";
-         path = "CoreData.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_51 = {
-         isa = "PBXFileReference";
-         path = "GenomeCoreData+Exports.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_52 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_53,
-            OBJ_54,
-            OBJ_55,
-         );
-         name = "GenomeFoundation";
-         path = "Sources/GenomeFoundation";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_53 = {
-         isa = "PBXFileReference";
-         path = "Foundation.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_54 = {
-         isa = "PBXFileReference";
-         path = "GenomeFoundation+Exports.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_55 = {
-         isa = "PBXFileReference";
-         path = "Node+Foundation.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_56 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_57,
-            OBJ_60,
-         );
-         path = "Tests";
-         sourceTree = "<group>";
-      };
-      OBJ_57 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_58,
-            OBJ_59,
-         );
-         name = "GenomeFoundationTests";
-         path = "Tests/GenomeFoundationTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_58 = {
-         isa = "PBXFileReference";
-         path = "JSONTests.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_59 = {
-         isa = "PBXFileReference";
-         path = "NodeFoundationTests.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_6 = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_60 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_61,
-            OBJ_62,
-            OBJ_63,
-            OBJ_64,
-            OBJ_65,
-            OBJ_66,
-            OBJ_67,
-            OBJ_68,
-         );
-         name = "GenomeTests";
-         path = "Tests/GenomeTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_61 = {
-         isa = "PBXFileReference";
-         path = "BasicTypes.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_62 = {
-         isa = "PBXFileReference";
-         path = "DictionaryKeyPathTests.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_63 = {
-         isa = "PBXFileReference";
-         path = "FromNodeOperatorTest.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_64 = {
-         isa = "PBXFileReference";
-         path = "NodeDataTypeTest.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_65 = {
-         isa = "PBXFileReference";
-         path = "PathIndexable.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_66 = {
-         isa = "PBXFileReference";
-         path = "SettableOperatorTest.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_67 = {
-         isa = "PBXFileReference";
-         path = "ToNodeOperatorTest.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_68 = {
-         isa = "PBXFileReference";
-         path = "TransformTests.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_69 = {
-         isa = "PBXFileReference";
-         path = "Images";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_7 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_8,
-            OBJ_11,
-            OBJ_14,
-            OBJ_42,
-            OBJ_49,
-            OBJ_52,
-         );
-         path = "Sources";
-         sourceTree = "<group>";
-      };
-      OBJ_70 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_71,
-            OBJ_72,
-            OBJ_73,
-            OBJ_74,
-            OBJ_75,
-            OBJ_76,
-            OBJ_77,
-            OBJ_78,
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_71 = {
-         isa = "PBXFileReference";
-         path = "PathIndexable.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_72 = {
-         isa = "PBXFileReference";
-         path = "Polymorphic.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_73 = {
-         isa = "PBXFileReference";
-         path = "Node.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_74 = {
-         isa = "PBXFileReference";
-         path = "Genome.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_75 = {
-         isa = "PBXFileReference";
-         path = "GenomeCoreData.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_76 = {
-         isa = "PBXFileReference";
-         path = "GenomeFoundation.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_77 = {
-         isa = "PBXFileReference";
-         path = "GenomeFoundationTests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_78 = {
-         isa = "PBXFileReference";
-         path = "GenomeTests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      OBJ_79 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_80;
-         buildPhases = (
-            OBJ_83,
-            OBJ_86,
-         );
-         dependencies = (
-         );
-         name = "PathIndexable";
-         productName = "PathIndexable";
-         productReference = OBJ_71;
-         productType = "com.apple.product-type.framework";
-      };
-      OBJ_8 = {
-         isa = "PBXGroup";
-         children = (
-            OBJ_9,
-            OBJ_10,
-         );
-         name = "PathIndexable";
-         path = "Packages/PathIndexable-1.0.0/Sources/PathIndexable";
-         sourceTree = "SOURCE_ROOT";
-      };
-      OBJ_80 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_81,
-            OBJ_82,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_81 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/PathIndexable_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "PathIndexable";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "PathIndexable";
-         };
-         name = "Debug";
-      };
-      OBJ_82 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/PathIndexable_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "PathIndexable";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "PathIndexable";
-         };
-         name = "Release";
-      };
-      OBJ_83 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_84,
-            OBJ_85,
-         );
-      };
-      OBJ_84 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_9;
-      };
-      OBJ_85 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_10;
-      };
-      OBJ_86 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      OBJ_87 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_88;
-         buildPhases = (
-            OBJ_91,
-            OBJ_94,
-         );
-         dependencies = (
-         );
-         name = "Polymorphic";
-         productName = "Polymorphic";
-         productReference = OBJ_72;
-         productType = "com.apple.product-type.framework";
-      };
-      OBJ_88 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_89,
-            OBJ_90,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_89 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/Polymorphic_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Polymorphic";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "Polymorphic";
-         };
-         name = "Debug";
-      };
-      OBJ_9 = {
-         isa = "PBXFileReference";
-         path = "PathIndexable+Subscripting.swift";
-         sourceTree = "<group>";
-      };
-      OBJ_90 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/Polymorphic_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Polymorphic";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "Polymorphic";
-         };
-         name = "Release";
-      };
-      OBJ_91 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_92,
-            OBJ_93,
-         );
-      };
-      OBJ_92 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_12;
-      };
-      OBJ_93 = {
-         isa = "PBXBuildFile";
-         fileRef = OBJ_13;
-      };
-      OBJ_94 = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      OBJ_95 = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = OBJ_96;
-         buildPhases = (
-            OBJ_99,
-            OBJ_122,
-         );
-         dependencies = (
-            OBJ_125,
-            OBJ_126,
-         );
-         name = "Node";
-         productName = "Node";
-         productReference = OBJ_73;
-         productType = "com.apple.product-type.framework";
-      };
-      OBJ_96 = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            OBJ_97,
-            OBJ_98,
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Debug";
-      };
-      OBJ_97 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/Node_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Node";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "Node";
-         };
-         name = "Debug";
-      };
-      OBJ_98 = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-            );
-            INFOPLIST_FILE = "Genome.xcodeproj/Node_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Node";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_VERSION = "3.0";
-            TARGET_NAME = "Node";
-         };
-         name = "Release";
-      };
-      OBJ_99 = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            OBJ_100,
-            OBJ_101,
-            OBJ_102,
-            OBJ_103,
-            OBJ_104,
-            OBJ_105,
-            OBJ_106,
-            OBJ_107,
-            OBJ_108,
-            OBJ_109,
-            OBJ_110,
-            OBJ_111,
-            OBJ_112,
-            OBJ_113,
-            OBJ_114,
-            OBJ_115,
-            OBJ_116,
-            OBJ_117,
-            OBJ_118,
-            OBJ_119,
-            OBJ_120,
-            OBJ_121,
-         );
-      };
-   };
-   rootObject = OBJ_1;
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		OBJ_100 /* NodeBacked.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* NodeBacked.swift */; };
+		OBJ_101 /* Bool+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Bool+Convertible.swift */; };
+		OBJ_102 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* Context.swift */; };
+		OBJ_103 /* Convertible+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Convertible+Init.swift */; };
+		OBJ_104 /* Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Convertible.swift */; };
+		OBJ_105 /* FloatingPoint+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* FloatingPoint+Convertible.swift */; };
+		OBJ_106 /* Integer+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Integer+Convertible.swift */; };
+		OBJ_107 /* Node+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Node+Convertible.swift */; };
+		OBJ_108 /* Sequence+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Sequence+Convertible.swift */; };
+		OBJ_109 /* String+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* String+Convertible.swift */; };
+		OBJ_110 /* UnsignedInteger+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* UnsignedInteger+Convertible.swift */; };
+		OBJ_111 /* Node+Accessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* Node+Accessors.swift */; };
+		OBJ_112 /* Node+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* Node+Equatable.swift */; };
+		OBJ_113 /* Node+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* Node+Exports.swift */; };
+		OBJ_114 /* Node+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* Node+Init.swift */; };
+		OBJ_115 /* Node+Literals.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* Node+Literals.swift */; };
+		OBJ_116 /* Node+PathIndexable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Node+PathIndexable.swift */; };
+		OBJ_117 /* Node+Polymorphic.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* Node+Polymorphic.swift */; };
+		OBJ_118 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* Node.swift */; };
+		OBJ_119 /* Node+Extract.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* Node+Extract.swift */; };
+		OBJ_120 /* Number.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* Number.swift */; };
+		OBJ_121 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* Errors.swift */; };
+		OBJ_123 /* PathIndexable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* PathIndexable.framework */; };
+		OBJ_124 /* Polymorphic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* Polymorphic.framework */; };
+		OBJ_132 /* Genome+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* Genome+Exports.swift */; };
+		OBJ_133 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* Map.swift */; };
+		OBJ_134 /* MappableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* MappableObject.swift */; };
+		OBJ_135 /* StandardOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* StandardOperators.swift */; };
+		OBJ_136 /* Transformers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* Transformers.swift */; };
+		OBJ_138 /* PathIndexable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* PathIndexable.framework */; };
+		OBJ_139 /* Polymorphic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* Polymorphic.framework */; };
+		OBJ_140 /* Node.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* Node.framework */; };
+		OBJ_149 /* CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* CoreData.swift */; };
+		OBJ_150 /* GenomeCoreData+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* GenomeCoreData+Exports.swift */; };
+		OBJ_152 /* PathIndexable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* PathIndexable.framework */; };
+		OBJ_153 /* Polymorphic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* Polymorphic.framework */; };
+		OBJ_154 /* Node.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* Node.framework */; };
+		OBJ_155 /* Genome.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* Genome.framework */; };
+		OBJ_156 /* GenomeFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* GenomeFoundation.framework */; };
+		OBJ_167 /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* Foundation.swift */; };
+		OBJ_168 /* GenomeFoundation+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* GenomeFoundation+Exports.swift */; };
+		OBJ_169 /* Node+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* Node+Foundation.swift */; };
+		OBJ_171 /* PathIndexable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* PathIndexable.framework */; };
+		OBJ_172 /* Polymorphic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* Polymorphic.framework */; };
+		OBJ_173 /* Node.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* Node.framework */; };
+		OBJ_174 /* Genome.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* Genome.framework */; };
+		OBJ_184 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_58 /* JSONTests.swift */; };
+		OBJ_185 /* NodeFoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_59 /* NodeFoundationTests.swift */; };
+		OBJ_187 /* PathIndexable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* PathIndexable.framework */; };
+		OBJ_188 /* Polymorphic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* Polymorphic.framework */; };
+		OBJ_189 /* Node.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* Node.framework */; };
+		OBJ_190 /* Genome.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* Genome.framework */; };
+		OBJ_191 /* GenomeFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* GenomeFoundation.framework */; };
+		OBJ_202 /* BasicTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* BasicTypes.swift */; };
+		OBJ_203 /* DictionaryKeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* DictionaryKeyPathTests.swift */; };
+		OBJ_204 /* FromNodeOperatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* FromNodeOperatorTest.swift */; };
+		OBJ_205 /* NodeDataTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_64 /* NodeDataTypeTest.swift */; };
+		OBJ_206 /* PathIndexable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_65 /* PathIndexable.swift */; };
+		OBJ_207 /* SettableOperatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_66 /* SettableOperatorTest.swift */; };
+		OBJ_208 /* ToNodeOperatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* ToNodeOperatorTest.swift */; };
+		OBJ_209 /* TransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* TransformTests.swift */; };
+		OBJ_211 /* PathIndexable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* PathIndexable.framework */; };
+		OBJ_212 /* Polymorphic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* Polymorphic.framework */; };
+		OBJ_213 /* Node.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* Node.framework */; };
+		OBJ_214 /* Genome.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* Genome.framework */; };
+		OBJ_84 /* PathIndexable+Subscripting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* PathIndexable+Subscripting.swift */; };
+		OBJ_85 /* PathIndexable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* PathIndexable.swift */; };
+		OBJ_92 /* Polymorphic.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Polymorphic.swift */; };
+		OBJ_93 /* String+Polymorphic.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* String+Polymorphic.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		22EF6F801EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_79;
+			remoteInfo = PathIndexable;
+		};
+		22EF6F811EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_87;
+			remoteInfo = Polymorphic;
+		};
+		22EF6F821EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_79;
+			remoteInfo = PathIndexable;
+		};
+		22EF6F831EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_87;
+			remoteInfo = Polymorphic;
+		};
+		22EF6F841EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_95;
+			remoteInfo = Node;
+		};
+		22EF6F851EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_79;
+			remoteInfo = PathIndexable;
+		};
+		22EF6F861EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_87;
+			remoteInfo = Polymorphic;
+		};
+		22EF6F871EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_95;
+			remoteInfo = Node;
+		};
+		22EF6F881EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_127;
+			remoteInfo = Genome;
+		};
+		22EF6F891EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_162;
+			remoteInfo = GenomeFoundation;
+		};
+		22EF6F8A1EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_79;
+			remoteInfo = PathIndexable;
+		};
+		22EF6F8B1EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_87;
+			remoteInfo = Polymorphic;
+		};
+		22EF6F8C1EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_95;
+			remoteInfo = Node;
+		};
+		22EF6F8D1EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_127;
+			remoteInfo = Genome;
+		};
+		22EF6F8E1EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_79;
+			remoteInfo = PathIndexable;
+		};
+		22EF6F8F1EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_87;
+			remoteInfo = Polymorphic;
+		};
+		22EF6F901EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_95;
+			remoteInfo = Node;
+		};
+		22EF6F911EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_127;
+			remoteInfo = Genome;
+		};
+		22EF6F921EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_162;
+			remoteInfo = GenomeFoundation;
+		};
+		22EF6F931EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_79;
+			remoteInfo = PathIndexable;
+		};
+		22EF6F941EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_87;
+			remoteInfo = Polymorphic;
+		};
+		22EF6F951EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_95;
+			remoteInfo = Node;
+		};
+		22EF6F961EC89F7C00ABC402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = OBJ_127;
+			remoteInfo = Genome;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		OBJ_10 /* PathIndexable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathIndexable.swift; sourceTree = "<group>"; };
+		OBJ_12 /* Polymorphic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Polymorphic.swift; sourceTree = "<group>"; };
+		OBJ_13 /* String+Polymorphic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Polymorphic.swift"; sourceTree = "<group>"; };
+		OBJ_15 /* NodeBacked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeBacked.swift; sourceTree = "<group>"; };
+		OBJ_17 /* Bool+Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Convertible.swift"; sourceTree = "<group>"; };
+		OBJ_18 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
+		OBJ_19 /* Convertible+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Convertible+Init.swift"; sourceTree = "<group>"; };
+		OBJ_20 /* Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Convertible.swift; sourceTree = "<group>"; };
+		OBJ_21 /* FloatingPoint+Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FloatingPoint+Convertible.swift"; sourceTree = "<group>"; };
+		OBJ_22 /* Integer+Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Integer+Convertible.swift"; sourceTree = "<group>"; };
+		OBJ_23 /* Node+Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Convertible.swift"; sourceTree = "<group>"; };
+		OBJ_24 /* Sequence+Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Convertible.swift"; sourceTree = "<group>"; };
+		OBJ_25 /* String+Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Convertible.swift"; sourceTree = "<group>"; };
+		OBJ_26 /* UnsignedInteger+Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnsignedInteger+Convertible.swift"; sourceTree = "<group>"; };
+		OBJ_28 /* Node+Accessors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Accessors.swift"; sourceTree = "<group>"; };
+		OBJ_29 /* Node+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Equatable.swift"; sourceTree = "<group>"; };
+		OBJ_30 /* Node+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Exports.swift"; sourceTree = "<group>"; };
+		OBJ_31 /* Node+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Init.swift"; sourceTree = "<group>"; };
+		OBJ_32 /* Node+Literals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Literals.swift"; sourceTree = "<group>"; };
+		OBJ_33 /* Node+PathIndexable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+PathIndexable.swift"; sourceTree = "<group>"; };
+		OBJ_34 /* Node+Polymorphic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Polymorphic.swift"; sourceTree = "<group>"; };
+		OBJ_35 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		OBJ_37 /* Node+Extract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Extract.swift"; sourceTree = "<group>"; };
+		OBJ_39 /* Number.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Number.swift; sourceTree = "<group>"; };
+		OBJ_41 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		OBJ_43 /* Genome+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Genome+Exports.swift"; sourceTree = "<group>"; };
+		OBJ_45 /* Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
+		OBJ_46 /* MappableObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappableObject.swift; sourceTree = "<group>"; };
+		OBJ_47 /* StandardOperators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardOperators.swift; sourceTree = "<group>"; };
+		OBJ_48 /* Transformers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transformers.swift; sourceTree = "<group>"; };
+		OBJ_50 /* CoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreData.swift; sourceTree = "<group>"; };
+		OBJ_51 /* GenomeCoreData+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenomeCoreData+Exports.swift"; sourceTree = "<group>"; };
+		OBJ_53 /* Foundation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Foundation.swift; sourceTree = "<group>"; };
+		OBJ_54 /* GenomeFoundation+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenomeFoundation+Exports.swift"; sourceTree = "<group>"; };
+		OBJ_55 /* Node+Foundation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Foundation.swift"; sourceTree = "<group>"; };
+		OBJ_58 /* JSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
+		OBJ_59 /* NodeFoundationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeFoundationTests.swift; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_61 /* BasicTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTypes.swift; sourceTree = "<group>"; };
+		OBJ_62 /* DictionaryKeyPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyPathTests.swift; sourceTree = "<group>"; };
+		OBJ_63 /* FromNodeOperatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FromNodeOperatorTest.swift; sourceTree = "<group>"; };
+		OBJ_64 /* NodeDataTypeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeDataTypeTest.swift; sourceTree = "<group>"; };
+		OBJ_65 /* PathIndexable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathIndexable.swift; sourceTree = "<group>"; };
+		OBJ_66 /* SettableOperatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettableOperatorTest.swift; sourceTree = "<group>"; };
+		OBJ_67 /* ToNodeOperatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToNodeOperatorTest.swift; sourceTree = "<group>"; };
+		OBJ_68 /* TransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformTests.swift; sourceTree = "<group>"; };
+		OBJ_69 /* Images */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Images; sourceTree = SOURCE_ROOT; };
+		OBJ_71 /* PathIndexable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PathIndexable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_72 /* Polymorphic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Polymorphic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_73 /* Node.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Node.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_74 /* Genome.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Genome.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_75 /* GenomeCoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GenomeCoreData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_76 /* GenomeFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = GenomeFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_77 /* GenomeFoundationTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = GenomeFoundationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_78 /* GenomeTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = GenomeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_9 /* PathIndexable+Subscripting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PathIndexable+Subscripting.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_122 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_123 /* PathIndexable.framework in Frameworks */,
+				OBJ_124 /* Polymorphic.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_137 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_138 /* PathIndexable.framework in Frameworks */,
+				OBJ_139 /* Polymorphic.framework in Frameworks */,
+				OBJ_140 /* Node.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_151 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_152 /* PathIndexable.framework in Frameworks */,
+				OBJ_153 /* Polymorphic.framework in Frameworks */,
+				OBJ_154 /* Node.framework in Frameworks */,
+				OBJ_155 /* Genome.framework in Frameworks */,
+				OBJ_156 /* GenomeFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_170 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_171 /* PathIndexable.framework in Frameworks */,
+				OBJ_172 /* Polymorphic.framework in Frameworks */,
+				OBJ_173 /* Node.framework in Frameworks */,
+				OBJ_174 /* Genome.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_186 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_187 /* PathIndexable.framework in Frameworks */,
+				OBJ_188 /* Polymorphic.framework in Frameworks */,
+				OBJ_189 /* Node.framework in Frameworks */,
+				OBJ_190 /* Genome.framework in Frameworks */,
+				OBJ_191 /* GenomeFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_210 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_211 /* PathIndexable.framework in Frameworks */,
+				OBJ_212 /* Polymorphic.framework in Frameworks */,
+				OBJ_213 /* Node.framework in Frameworks */,
+				OBJ_214 /* Genome.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_86 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_94 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_11 /* Polymorphic */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_12 /* Polymorphic.swift */,
+				OBJ_13 /* String+Polymorphic.swift */,
+			);
+			name = Polymorphic;
+			path = "Packages/Polymorphic-1.0.0/Sources";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_14 /* Node */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* NodeBacked.swift */,
+				OBJ_16 /* Convertible */,
+				OBJ_27 /* Core */,
+				OBJ_36 /* Extract */,
+				OBJ_38 /* Number */,
+				OBJ_40 /* Utilities */,
+			);
+			name = Node;
+			path = "Packages/Node-1.0.1/Sources/Node";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_16 /* Convertible */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_17 /* Bool+Convertible.swift */,
+				OBJ_18 /* Context.swift */,
+				OBJ_19 /* Convertible+Init.swift */,
+				OBJ_20 /* Convertible.swift */,
+				OBJ_21 /* FloatingPoint+Convertible.swift */,
+				OBJ_22 /* Integer+Convertible.swift */,
+				OBJ_23 /* Node+Convertible.swift */,
+				OBJ_24 /* Sequence+Convertible.swift */,
+				OBJ_25 /* String+Convertible.swift */,
+				OBJ_26 /* UnsignedInteger+Convertible.swift */,
+			);
+			path = Convertible;
+			sourceTree = "<group>";
+		};
+		OBJ_27 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_28 /* Node+Accessors.swift */,
+				OBJ_29 /* Node+Equatable.swift */,
+				OBJ_30 /* Node+Exports.swift */,
+				OBJ_31 /* Node+Init.swift */,
+				OBJ_32 /* Node+Literals.swift */,
+				OBJ_33 /* Node+PathIndexable.swift */,
+				OBJ_34 /* Node+Polymorphic.swift */,
+				OBJ_35 /* Node.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		OBJ_36 /* Extract */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_37 /* Node+Extract.swift */,
+			);
+			path = Extract;
+			sourceTree = "<group>";
+		};
+		OBJ_38 /* Number */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_39 /* Number.swift */,
+			);
+			path = Number;
+			sourceTree = "<group>";
+		};
+		OBJ_40 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_41 /* Errors.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		OBJ_42 /* Genome */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_43 /* Genome+Exports.swift */,
+				OBJ_44 /* Mapping */,
+			);
+			name = Genome;
+			path = Sources/Genome;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_44 /* Mapping */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_45 /* Map.swift */,
+				OBJ_46 /* MappableObject.swift */,
+				OBJ_47 /* StandardOperators.swift */,
+				OBJ_48 /* Transformers.swift */,
+			);
+			path = Mapping;
+			sourceTree = "<group>";
+		};
+		OBJ_49 /* GenomeCoreData */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_50 /* CoreData.swift */,
+				OBJ_51 /* GenomeCoreData+Exports.swift */,
+			);
+			name = GenomeCoreData;
+			path = Sources/GenomeCoreData;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_56 /* Tests */,
+				OBJ_69 /* Images */,
+				OBJ_70 /* Products */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_52 /* GenomeFoundation */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_53 /* Foundation.swift */,
+				OBJ_54 /* GenomeFoundation+Exports.swift */,
+				OBJ_55 /* Node+Foundation.swift */,
+			);
+			name = GenomeFoundation;
+			path = Sources/GenomeFoundation;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_56 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_57 /* GenomeFoundationTests */,
+				OBJ_60 /* GenomeTests */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		OBJ_57 /* GenomeFoundationTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_58 /* JSONTests.swift */,
+				OBJ_59 /* NodeFoundationTests.swift */,
+			);
+			name = GenomeFoundationTests;
+			path = Tests/GenomeFoundationTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_60 /* GenomeTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_61 /* BasicTypes.swift */,
+				OBJ_62 /* DictionaryKeyPathTests.swift */,
+				OBJ_63 /* FromNodeOperatorTest.swift */,
+				OBJ_64 /* NodeDataTypeTest.swift */,
+				OBJ_65 /* PathIndexable.swift */,
+				OBJ_66 /* SettableOperatorTest.swift */,
+				OBJ_67 /* ToNodeOperatorTest.swift */,
+				OBJ_68 /* TransformTests.swift */,
+			);
+			name = GenomeTests;
+			path = Tests/GenomeTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* PathIndexable */,
+				OBJ_11 /* Polymorphic */,
+				OBJ_14 /* Node */,
+				OBJ_42 /* Genome */,
+				OBJ_49 /* GenomeCoreData */,
+				OBJ_52 /* GenomeFoundation */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		OBJ_70 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_71 /* PathIndexable.framework */,
+				OBJ_72 /* Polymorphic.framework */,
+				OBJ_73 /* Node.framework */,
+				OBJ_74 /* Genome.framework */,
+				OBJ_75 /* GenomeCoreData.framework */,
+				OBJ_76 /* GenomeFoundation.framework */,
+				OBJ_77 /* GenomeFoundationTests.xctest */,
+				OBJ_78 /* GenomeTests.xctest */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_8 /* PathIndexable */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* PathIndexable+Subscripting.swift */,
+				OBJ_10 /* PathIndexable.swift */,
+			);
+			name = PathIndexable;
+			path = "Packages/PathIndexable-1.0.0/Sources/PathIndexable";
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		OBJ_127 /* Genome */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_128 /* Build configuration list for PBXNativeTarget "Genome" */;
+			buildPhases = (
+				OBJ_131 /* Sources */,
+				OBJ_137 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_141 /* PBXTargetDependency */,
+				OBJ_142 /* PBXTargetDependency */,
+				OBJ_143 /* PBXTargetDependency */,
+			);
+			name = Genome;
+			productName = Genome;
+			productReference = OBJ_74 /* Genome.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		OBJ_144 /* GenomeCoreData */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_145 /* Build configuration list for PBXNativeTarget "GenomeCoreData" */;
+			buildPhases = (
+				OBJ_148 /* Sources */,
+				OBJ_151 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_157 /* PBXTargetDependency */,
+				OBJ_158 /* PBXTargetDependency */,
+				OBJ_159 /* PBXTargetDependency */,
+				OBJ_160 /* PBXTargetDependency */,
+				OBJ_161 /* PBXTargetDependency */,
+			);
+			name = GenomeCoreData;
+			productName = GenomeCoreData;
+			productReference = OBJ_75 /* GenomeCoreData.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		OBJ_162 /* GenomeFoundation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_163 /* Build configuration list for PBXNativeTarget "GenomeFoundation" */;
+			buildPhases = (
+				OBJ_166 /* Sources */,
+				OBJ_170 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_175 /* PBXTargetDependency */,
+				OBJ_176 /* PBXTargetDependency */,
+				OBJ_177 /* PBXTargetDependency */,
+				OBJ_178 /* PBXTargetDependency */,
+			);
+			name = GenomeFoundation;
+			productName = GenomeFoundation;
+			productReference = OBJ_76 /* GenomeFoundation.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		OBJ_179 /* GenomeFoundationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_180 /* Build configuration list for PBXNativeTarget "GenomeFoundationTests" */;
+			buildPhases = (
+				OBJ_183 /* Sources */,
+				OBJ_186 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_192 /* PBXTargetDependency */,
+				OBJ_193 /* PBXTargetDependency */,
+				OBJ_194 /* PBXTargetDependency */,
+				OBJ_195 /* PBXTargetDependency */,
+				OBJ_196 /* PBXTargetDependency */,
+			);
+			name = GenomeFoundationTests;
+			productName = GenomeFoundationTests;
+			productReference = OBJ_77 /* GenomeFoundationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		OBJ_197 /* GenomeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_198 /* Build configuration list for PBXNativeTarget "GenomeTests" */;
+			buildPhases = (
+				OBJ_201 /* Sources */,
+				OBJ_210 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_215 /* PBXTargetDependency */,
+				OBJ_216 /* PBXTargetDependency */,
+				OBJ_217 /* PBXTargetDependency */,
+				OBJ_218 /* PBXTargetDependency */,
+			);
+			name = GenomeTests;
+			productName = GenomeTests;
+			productReference = OBJ_78 /* GenomeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		OBJ_79 /* PathIndexable */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_80 /* Build configuration list for PBXNativeTarget "PathIndexable" */;
+			buildPhases = (
+				OBJ_83 /* Sources */,
+				OBJ_86 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PathIndexable;
+			productName = PathIndexable;
+			productReference = OBJ_71 /* PathIndexable.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		OBJ_87 /* Polymorphic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_88 /* Build configuration list for PBXNativeTarget "Polymorphic" */;
+			buildPhases = (
+				OBJ_91 /* Sources */,
+				OBJ_94 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Polymorphic;
+			productName = Polymorphic;
+			productReference = OBJ_72 /* Polymorphic.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		OBJ_95 /* Node */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_96 /* Build configuration list for PBXNativeTarget "Node" */;
+			buildPhases = (
+				OBJ_99 /* Sources */,
+				OBJ_122 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_125 /* PBXTargetDependency */,
+				OBJ_126 /* PBXTargetDependency */,
+			);
+			name = Node;
+			productName = Node;
+			productReference = OBJ_73 /* Node.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Genome" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_70 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				OBJ_79 /* PathIndexable */,
+				OBJ_87 /* Polymorphic */,
+				OBJ_95 /* Node */,
+				OBJ_127 /* Genome */,
+				OBJ_144 /* GenomeCoreData */,
+				OBJ_162 /* GenomeFoundation */,
+				OBJ_179 /* GenomeFoundationTests */,
+				OBJ_197 /* GenomeTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_131 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_132 /* Genome+Exports.swift in Sources */,
+				OBJ_133 /* Map.swift in Sources */,
+				OBJ_134 /* MappableObject.swift in Sources */,
+				OBJ_135 /* StandardOperators.swift in Sources */,
+				OBJ_136 /* Transformers.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_148 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_149 /* CoreData.swift in Sources */,
+				OBJ_150 /* GenomeCoreData+Exports.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_166 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_167 /* Foundation.swift in Sources */,
+				OBJ_168 /* GenomeFoundation+Exports.swift in Sources */,
+				OBJ_169 /* Node+Foundation.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_183 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_184 /* JSONTests.swift in Sources */,
+				OBJ_185 /* NodeFoundationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_201 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_202 /* BasicTypes.swift in Sources */,
+				OBJ_203 /* DictionaryKeyPathTests.swift in Sources */,
+				OBJ_204 /* FromNodeOperatorTest.swift in Sources */,
+				OBJ_205 /* NodeDataTypeTest.swift in Sources */,
+				OBJ_206 /* PathIndexable.swift in Sources */,
+				OBJ_207 /* SettableOperatorTest.swift in Sources */,
+				OBJ_208 /* ToNodeOperatorTest.swift in Sources */,
+				OBJ_209 /* TransformTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_83 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_84 /* PathIndexable+Subscripting.swift in Sources */,
+				OBJ_85 /* PathIndexable.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_91 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_92 /* Polymorphic.swift in Sources */,
+				OBJ_93 /* String+Polymorphic.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_99 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_100 /* NodeBacked.swift in Sources */,
+				OBJ_101 /* Bool+Convertible.swift in Sources */,
+				OBJ_102 /* Context.swift in Sources */,
+				OBJ_103 /* Convertible+Init.swift in Sources */,
+				OBJ_104 /* Convertible.swift in Sources */,
+				OBJ_105 /* FloatingPoint+Convertible.swift in Sources */,
+				OBJ_106 /* Integer+Convertible.swift in Sources */,
+				OBJ_107 /* Node+Convertible.swift in Sources */,
+				OBJ_108 /* Sequence+Convertible.swift in Sources */,
+				OBJ_109 /* String+Convertible.swift in Sources */,
+				OBJ_110 /* UnsignedInteger+Convertible.swift in Sources */,
+				OBJ_111 /* Node+Accessors.swift in Sources */,
+				OBJ_112 /* Node+Equatable.swift in Sources */,
+				OBJ_113 /* Node+Exports.swift in Sources */,
+				OBJ_114 /* Node+Init.swift in Sources */,
+				OBJ_115 /* Node+Literals.swift in Sources */,
+				OBJ_116 /* Node+PathIndexable.swift in Sources */,
+				OBJ_117 /* Node+Polymorphic.swift in Sources */,
+				OBJ_118 /* Node.swift in Sources */,
+				OBJ_119 /* Node+Extract.swift in Sources */,
+				OBJ_120 /* Number.swift in Sources */,
+				OBJ_121 /* Errors.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_125 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_79 /* PathIndexable */;
+			targetProxy = 22EF6F801EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_126 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_87 /* Polymorphic */;
+			targetProxy = 22EF6F811EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_141 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_79 /* PathIndexable */;
+			targetProxy = 22EF6F821EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_142 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_87 /* Polymorphic */;
+			targetProxy = 22EF6F831EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_143 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_95 /* Node */;
+			targetProxy = 22EF6F841EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_157 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_79 /* PathIndexable */;
+			targetProxy = 22EF6F851EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_158 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_87 /* Polymorphic */;
+			targetProxy = 22EF6F861EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_159 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_95 /* Node */;
+			targetProxy = 22EF6F871EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_160 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_127 /* Genome */;
+			targetProxy = 22EF6F881EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_161 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_162 /* GenomeFoundation */;
+			targetProxy = 22EF6F891EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_175 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_79 /* PathIndexable */;
+			targetProxy = 22EF6F8A1EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_176 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_87 /* Polymorphic */;
+			targetProxy = 22EF6F8B1EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_177 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_95 /* Node */;
+			targetProxy = 22EF6F8C1EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_178 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_127 /* Genome */;
+			targetProxy = 22EF6F8D1EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_192 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_79 /* PathIndexable */;
+			targetProxy = 22EF6F8E1EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_193 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_87 /* Polymorphic */;
+			targetProxy = 22EF6F8F1EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_194 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_95 /* Node */;
+			targetProxy = 22EF6F901EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_195 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_127 /* Genome */;
+			targetProxy = 22EF6F911EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_196 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_162 /* GenomeFoundation */;
+			targetProxy = 22EF6F921EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_215 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_79 /* PathIndexable */;
+			targetProxy = 22EF6F931EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_216 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_87 /* Polymorphic */;
+			targetProxy = 22EF6F941EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_217 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_95 /* Node */;
+			targetProxy = 22EF6F951EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+		OBJ_218 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = OBJ_127 /* Genome */;
+			targetProxy = 22EF6F961EC89F7C00ABC402 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_129 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/Genome_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Genome;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Genome;
+			};
+			name = Debug;
+		};
+		OBJ_130 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/Genome_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Genome;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Genome;
+			};
+			name = Release;
+		};
+		OBJ_146 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeCoreData_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = GenomeCoreData;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeCoreData;
+			};
+			name = Debug;
+		};
+		OBJ_147 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeCoreData_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = GenomeCoreData;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeCoreData;
+			};
+			name = Release;
+		};
+		OBJ_164 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeFoundation_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = GenomeFoundation;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeFoundation;
+			};
+			name = Debug;
+		};
+		OBJ_165 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeFoundation_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = GenomeFoundation;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeFoundation;
+			};
+			name = Release;
+		};
+		OBJ_181 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeFoundationTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeFoundationTests;
+			};
+			name = Debug;
+		};
+		OBJ_182 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeFoundationTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeFoundationTests;
+			};
+			name = Release;
+		};
+		OBJ_199 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeTests;
+			};
+			name = Debug;
+		};
+		OBJ_200 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/GenomeTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = GenomeTests;
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				USE_HEADERMAP = NO;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				USE_HEADERMAP = NO;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/PathIndexable_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = PathIndexable;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = PathIndexable;
+			};
+			name = Debug;
+		};
+		OBJ_82 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/PathIndexable_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = PathIndexable;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = PathIndexable;
+			};
+			name = Release;
+		};
+		OBJ_89 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/Polymorphic_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Polymorphic;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Polymorphic;
+			};
+			name = Debug;
+		};
+		OBJ_90 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/Polymorphic_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Polymorphic;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Polymorphic;
+			};
+			name = Release;
+		};
+		OBJ_97 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/Node_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Node;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Node;
+			};
+			name = Debug;
+		};
+		OBJ_98 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = Genome.xcodeproj/Node_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Node;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Node;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_128 /* Build configuration list for PBXNativeTarget "Genome" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_129 /* Debug */,
+				OBJ_130 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_145 /* Build configuration list for PBXNativeTarget "GenomeCoreData" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_146 /* Debug */,
+				OBJ_147 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_163 /* Build configuration list for PBXNativeTarget "GenomeFoundation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_164 /* Debug */,
+				OBJ_165 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_180 /* Build configuration list for PBXNativeTarget "GenomeFoundationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_181 /* Debug */,
+				OBJ_182 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_198 /* Build configuration list for PBXNativeTarget "GenomeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_199 /* Debug */,
+				OBJ_200 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_2 /* Build configuration list for PBXProject "Genome" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_80 /* Build configuration list for PBXNativeTarget "PathIndexable" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_81 /* Debug */,
+				OBJ_82 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_88 /* Build configuration list for PBXNativeTarget "Polymorphic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_89 /* Debug */,
+				OBJ_90 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_96 /* Build configuration list for PBXNativeTarget "Node" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_97 /* Debug */,
+				OBJ_98 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/Genome.xcodeproj/project.pbxproj
+++ b/Genome.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		22EF6F9A1EC8A11600ABC402 /* Optional+unwrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EF6F991EC8A11600ABC402 /* Optional+unwrap.swift */; };
 		OBJ_100 /* NodeBacked.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* NodeBacked.swift */; };
 		OBJ_101 /* Bool+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Bool+Convertible.swift */; };
 		OBJ_102 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* Context.swift */; };
@@ -243,6 +244,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		22EF6F991EC8A11600ABC402 /* Optional+unwrap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+unwrap.swift"; sourceTree = "<group>"; };
 		OBJ_10 /* PathIndexable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathIndexable.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Polymorphic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Polymorphic.swift; sourceTree = "<group>"; };
 		OBJ_13 /* String+Polymorphic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Polymorphic.swift"; sourceTree = "<group>"; };
@@ -548,6 +550,7 @@
 				OBJ_66 /* SettableOperatorTest.swift */,
 				OBJ_67 /* ToNodeOperatorTest.swift */,
 				OBJ_68 /* TransformTests.swift */,
+				22EF6F991EC8A11600ABC402 /* Optional+unwrap.swift */,
 			);
 			name = GenomeTests;
 			path = Tests/GenomeTests;
@@ -822,6 +825,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				22EF6F9A1EC8A11600ABC402 /* Optional+unwrap.swift in Sources */,
 				OBJ_202 /* BasicTypes.swift in Sources */,
 				OBJ_203 /* DictionaryKeyPathTests.swift in Sources */,
 				OBJ_204 /* FromNodeOperatorTest.swift in Sources */,

--- a/Genome.xcodeproj/project.pbxproj
+++ b/Genome.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		22EF6F9A1EC8A11600ABC402 /* Optional+unwrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EF6F991EC8A11600ABC402 /* Optional+unwrap.swift */; };
+		22EF6F9C1EC8A6FD00ABC402 /* Overloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EF6F9B1EC8A6FD00ABC402 /* Overloads.swift */; };
 		OBJ_100 /* NodeBacked.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* NodeBacked.swift */; };
 		OBJ_101 /* Bool+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Bool+Convertible.swift */; };
 		OBJ_102 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* Context.swift */; };
@@ -245,6 +246,7 @@
 
 /* Begin PBXFileReference section */
 		22EF6F991EC8A11600ABC402 /* Optional+unwrap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+unwrap.swift"; sourceTree = "<group>"; };
+		22EF6F9B1EC8A6FD00ABC402 /* Overloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Overloads.swift; sourceTree = "<group>"; };
 		OBJ_10 /* PathIndexable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathIndexable.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Polymorphic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Polymorphic.swift; sourceTree = "<group>"; };
 		OBJ_13 /* String+Polymorphic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Polymorphic.swift"; sourceTree = "<group>"; };
@@ -551,6 +553,7 @@
 				OBJ_67 /* ToNodeOperatorTest.swift */,
 				OBJ_68 /* TransformTests.swift */,
 				22EF6F991EC8A11600ABC402 /* Optional+unwrap.swift */,
+				22EF6F9B1EC8A6FD00ABC402 /* Overloads.swift */,
 			);
 			name = GenomeTests;
 			path = Tests/GenomeTests;
@@ -832,6 +835,7 @@
 				OBJ_205 /* NodeDataTypeTest.swift in Sources */,
 				OBJ_206 /* PathIndexable.swift in Sources */,
 				OBJ_207 /* SettableOperatorTest.swift in Sources */,
+				22EF6F9C1EC8A6FD00ABC402 /* Overloads.swift in Sources */,
 				OBJ_208 /* ToNodeOperatorTest.swift in Sources */,
 				OBJ_209 /* TransformTests.swift in Sources */,
 			);

--- a/Genome.xcodeproj/xcshareddata/xcschemes/Genome.xcscheme
+++ b/Genome.xcodeproj/xcshareddata/xcschemes/Genome.xcscheme
@@ -1,82 +1,161 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion = "9999" version = "1.3">
-  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "PathIndexable"
-          ReferencedContainer = "container:Genome.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "Polymorphic"
-          ReferencedContainer = "container:Genome.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "Node"
-          ReferencedContainer = "container:Genome.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "Genome"
-          ReferencedContainer = "container:Genome.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "GenomeCoreData"
-          ReferencedContainer = "container:Genome.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "GenomeFoundation"
-          ReferencedContainer = "container:Genome.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction
-    buildConfiguration = "Debug"
-    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-    shouldUseLaunchSchemeArgsEnv = "YES"
-    codeCoverageEnabled = "NO">
-    <Testables>
-    <TestableReference
-      skipped = "NO">
-      <BuildableReference
-        BuildableIdentifier = "primary"
-        BuildableName = "'$(TARGET_NAME)'"
-        BlueprintName = "GenomeFoundationTests"
-        ReferencedContainer = "container:Genome.xcodeproj">
-      </BuildableReference>
-    </TestableReference>
-    <TestableReference
-      skipped = "NO">
-      <BuildableReference
-        BuildableIdentifier = "primary"
-        BuildableName = "'$(TARGET_NAME)'"
-        BlueprintName = "GenomeTests"
-        ReferencedContainer = "container:Genome.xcodeproj">
-      </BuildableReference>
-    </TestableReference>
-    </Testables>
-  </TestAction>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_79"
+               BuildableName = "PathIndexable.framework"
+               BlueprintName = "PathIndexable"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_87"
+               BuildableName = "Polymorphic.framework"
+               BlueprintName = "Polymorphic"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_95"
+               BuildableName = "Node.framework"
+               BlueprintName = "Node"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_127"
+               BuildableName = "Genome.framework"
+               BlueprintName = "Genome"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_144"
+               BuildableName = "GenomeCoreData.framework"
+               BlueprintName = "GenomeCoreData"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_162"
+               BuildableName = "GenomeFoundation.framework"
+               BlueprintName = "GenomeFoundation"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_179"
+               BuildableName = "GenomeFoundationTests.xctest"
+               BlueprintName = "GenomeFoundationTests"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OBJ_197"
+               BuildableName = "GenomeTests.xctest"
+               BlueprintName = "GenomeTests"
+               ReferencedContainer = "container:Genome.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "OBJ_79"
+            BuildableName = "PathIndexable.framework"
+            BlueprintName = "PathIndexable"
+            ReferencedContainer = "container:Genome.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/Tests/GenomeTests/BasicTypes.swift
+++ b/Tests/GenomeTests/BasicTypes.swift
@@ -81,11 +81,11 @@ class BasicTypeTests: XCTestCase {
         XCTAssert(basic.string == "hello")
         
         let node = try basic.makeNode()
-        let int = node["int"]!.int!
-        let float = node["float"]!.float!
-        let double = node["double"]!.double!
-        let bool = node["bool"]!.bool!
-        let string = node["string"]!.string!
+        let int = try node["int"].unwrap().int.unwrap()
+        let float = try node["float"].unwrap().float.unwrap()
+        let double = try node["double"].unwrap().double.unwrap()
+        let bool = try node["bool"].unwrap().bool.unwrap()
+        let string = try node["string"].unwrap().string.unwrap()
         XCTAssert(int == 1)
         XCTAssert(float == 1.5)
         XCTAssert(double == 2.5)
@@ -102,11 +102,11 @@ class BasicTypeTests: XCTestCase {
         XCTAssert(basic.strings == ["hello"])
         
         let node = try basic.makeNode()
-        let ints = node["ints"]!.array!.flatMap { $0.int }
-        let floats = node["floats"]!.array!.flatMap { $0.float }
-        let doubles = node["doubles"]!.array!.flatMap { $0.double }
-        let bools = node["bools"]!.array!.flatMap { $0.bool }
-        let strings = node["strings"]!.array!.flatMap { $0.string }
+        let ints = try node["ints"].unwrap().array.unwrap().flatMap { $0.int }
+        let floats = try node["floats"].unwrap().array.unwrap().flatMap { $0.float }
+        let doubles = try node["doubles"].unwrap().array.unwrap().flatMap { $0.double }
+        let bools = try node["bools"].unwrap().array.unwrap().flatMap { $0.bool }
+        let strings = try node["strings"].unwrap().array.unwrap().flatMap { $0.string }
         XCTAssert(ints == [1])
         XCTAssert(floats == [1.5])
         XCTAssert(doubles == [2.5])

--- a/Tests/GenomeTests/BasicTypes.swift
+++ b/Tests/GenomeTests/BasicTypes.swift
@@ -74,11 +74,11 @@ class BasicTypeTests: XCTestCase {
     
     func testBasic() throws {
         let basic = try Basic(node: BasicTestNode)
-        XCTAssert(basic.int == 1)
-        XCTAssert(basic.float == 1.5)
-        XCTAssert(basic.double == 2.5)
-        XCTAssert(basic.bool == true)
-        XCTAssert(basic.string == "hello")
+        XCTAssertEqual(basic.int, 1)
+        XCTAssertEqual(basic.float, 1.5)
+        XCTAssertEqual(basic.double, 2.5)
+        XCTAssertEqual(basic.bool, true)
+        XCTAssertEqual(basic.string, "hello")
         
         let node = try basic.makeNode()
         let int = try node["int"].unwrap().int.unwrap()
@@ -86,20 +86,20 @@ class BasicTypeTests: XCTestCase {
         let double = try node["double"].unwrap().double.unwrap()
         let bool = try node["bool"].unwrap().bool.unwrap()
         let string = try node["string"].unwrap().string.unwrap()
-        XCTAssert(int == 1)
-        XCTAssert(float == 1.5)
-        XCTAssert(double == 2.5)
-        XCTAssert(bool == true)
-        XCTAssert(string == "hello")
+        XCTAssertEqual(int, 1)
+        XCTAssertEqual(float, 1.5)
+        XCTAssertEqual(double, 2.5)
+        XCTAssertEqual(bool, true)
+        XCTAssertEqual(string, "hello")
     }
     
     func testBasicArrays() throws {
         let basic = try BasicArrays(node: .object(BasicArraysTestNode))
-        XCTAssert(basic.ints == [1])
-        XCTAssert(basic.floats == [1.5])
-        XCTAssert(basic.doubles == [2.5])
-        XCTAssert(basic.bools == [true])
-        XCTAssert(basic.strings == ["hello"])
+        XCTAssertEqual(basic.ints, [1])
+        XCTAssertEqual(basic.floats, [1.5])
+        XCTAssertEqual(basic.doubles, [2.5])
+        XCTAssertEqual(basic.bools, [true])
+        XCTAssertEqual(basic.strings, ["hello"])
         
         let node = try basic.makeNode()
         let ints = try node["ints"].unwrap().array.unwrap().flatMap { $0.int }
@@ -107,10 +107,10 @@ class BasicTypeTests: XCTestCase {
         let doubles = try node["doubles"].unwrap().array.unwrap().flatMap { $0.double }
         let bools = try node["bools"].unwrap().array.unwrap().flatMap { $0.bool }
         let strings = try node["strings"].unwrap().array.unwrap().flatMap { $0.string }
-        XCTAssert(ints == [1])
-        XCTAssert(floats == [1.5])
-        XCTAssert(doubles == [2.5])
-        XCTAssert(bools == [true])
-        XCTAssert(strings == ["hello"])
+        XCTAssertEqual(ints, [1])
+        XCTAssertEqual(floats, [1.5])
+        XCTAssertEqual(doubles, [2.5])
+        XCTAssertEqual(bools, [true])
+        XCTAssertEqual(strings, ["hello"])
     }
 }

--- a/Tests/GenomeTests/DictionaryKeyPathTests.swift
+++ b/Tests/GenomeTests/DictionaryKeyPathTests.swift
@@ -23,7 +23,7 @@ class DictionaryKeyPathTests: XCTestCase {
 
         var node = TestDictionary
 
-        let value: String! = node["one", "two"]?.string
+        let value = node["one", "two"]?.string
         XCTAssert(value == "Found me!")
 
         node["path", "to", "new", "value"] = "Hello!"

--- a/Tests/GenomeTests/DictionaryKeyPathTests.swift
+++ b/Tests/GenomeTests/DictionaryKeyPathTests.swift
@@ -24,11 +24,11 @@ class DictionaryKeyPathTests: XCTestCase {
         var node = TestDictionary
 
         let value = node["one", "two"]?.string
-        XCTAssert(value == "Found me!")
+        XCTAssertEqual(value, "Found me!")
 
         node["path", "to", "new", "value"] = "Hello!"
         let setVal = node["path", "to", "new", "value"]
-        XCTAssert(setVal == "Hello!")
+        XCTAssertEqual(setVal, "Hello!")
     }
     
 }

--- a/Tests/GenomeTests/FromNodeOperatorTest.swift
+++ b/Tests/GenomeTests/FromNodeOperatorTest.swift
@@ -239,13 +239,13 @@ class FromNodeOperatorTestMapped: XCTestCase {
         var optionalGroups: [String : [Person]]?
         try optionalGroups <~ map["groups"]
         
-        for groupsArray in [groups, optionalGroups!] {
+        for groupsArray in [groups, try optionalGroups.unwrap()] {
             XCTAssert(groupsArray.count == 2)
             
-            let boys = groupsArray["boys"]!
+            let boys = try groupsArray["boys"].unwrap()
             XCTAssert(boys ==  [joeObject, justinObject, philObject])
             
-            let girls = groupsArray["girls"]!
+            let girls = try groupsArray["girls"].unwrap()
             XCTAssert(girls ==  [janeObject])
         }
         
@@ -260,7 +260,7 @@ class FromNodeOperatorTestMapped: XCTestCase {
         var optionalPeople: Set<Person>?
         try optionalPeople <~ map["duplicated_people"]
         
-        for peopleSet in [people, optionalPeople!] {
+        for peopleSet in [people, try optionalPeople.unwrap()] {
             XCTAssert(peopleSet.count == 2)
             XCTAssert(peopleSet.contains(joeObject))
             XCTAssert(peopleSet.contains(janeObject))

--- a/Tests/GenomeTests/FromNodeOperatorTest.swift
+++ b/Tests/GenomeTests/FromNodeOperatorTest.swift
@@ -115,31 +115,31 @@ class FromNodeOperatorTestBasic: XCTestCase {
     func testString() throws {
         var string = ""
         try string <~ map["string"]
-        XCTAssert(string == "pass")
+        XCTAssertEqual(string, "pass")
     }
 
     func testStringOptional() throws {
         var string: String? = nil
         try string <~ map["string"]
-        XCTAssert(string == "pass")
+        XCTAssertEqual(string, "pass")
     }
 
     func testStringsArray() throws {
         var strings: [String] = []
         try strings <~ map["strings"]
-        XCTAssert(strings == ["one", "two", "three"])
+        XCTAssertEqual(strings, ["one", "two", "three"])
     }
 
     func testStringsArrayOptional() throws {
         var strings: [String]? = nil
         try strings <~ map["strings"]
-        XCTAssert(strings! == ["one", "two", "three"])
+        XCTAssertEqual(strings!, ["one", "two", "three"])
     }
 
     func testInt() throws {
         var int = 0
         try int <~ map["int"]
-        XCTAssert(int == 272)
+        XCTAssertEqual(int, 272)
     }
 
     func testEmptyInt() throws {
@@ -173,45 +173,45 @@ class FromNodeOperatorTestMapped: XCTestCase {
     func testMappableObject() throws {
         var person: Person = Person()
         try person <~ map["person"]
-        XCTAssert(person == joeObject)
+        XCTAssertEqual(person, joeObject)
         
         var optionalPerson: Person?
         try optionalPerson <~ map["person"]
-        XCTAssert(optionalPerson! == joeObject)
+        XCTAssertEqual(optionalPerson!, joeObject)
         
         var emptyPerson: Person?
         try emptyPerson <~ map["i-dont-exist"]
-        XCTAssert(emptyPerson == nil)
+        XCTAssertEqual(emptyPerson, nil)
     }
     
     func testMappableArray() throws {
         var people: [Person] = []
         try people <~ map["people"]
-        XCTAssert(people ==  [joeObject, janeObject])
+        XCTAssertEqual(people,  [joeObject, janeObject])
         
         var optionalPeople: [Person]?
         try optionalPeople <~ map["people"]
-        XCTAssert(optionalPeople! ==  [joeObject, janeObject])
+        XCTAssertEqual(optionalPeople!,  [joeObject, janeObject])
         
         var emptyPersons: [Person]?
         try emptyPersons <~ map["i_dont_exist"]
-        XCTAssert(emptyPersons == nil)
+        XCTAssertNil(emptyPersons)
     }
     
     func testMappableArrayOfArrays() throws {
         var orderedGroups: [[Person]] = []
         try orderedGroups <~ map["ordered_groups"]
-        XCTAssert(orderedGroups[0] ==  [joeObject, justinObject, philObject])
-        XCTAssert(orderedGroups[1] ==  [janeObject])
+        XCTAssertEqual(orderedGroups[0],  [joeObject, justinObject, philObject])
+        XCTAssertEqual(orderedGroups[1],  [janeObject])
         
         var optionalOrderedGroups: [[Person]]?
         try optionalOrderedGroups <~ map["ordered_groups"]
-        XCTAssert(optionalOrderedGroups![0] ==  [joeObject, justinObject, philObject])
-        XCTAssert(optionalOrderedGroups![1] ==  [janeObject])
+        XCTAssertEqual(optionalOrderedGroups![0],  [joeObject, justinObject, philObject])
+        XCTAssertEqual(optionalOrderedGroups![1],  [janeObject])
         
         var emptyOrderedGroups: [[Person]]?
         try emptyOrderedGroups <~ map["i_dont_exist"]
-        XCTAssert(emptyOrderedGroups == nil)
+        XCTAssertNil(emptyOrderedGroups)
     }
     
     func testMappableDictionary() throws {
@@ -222,15 +222,15 @@ class FromNodeOperatorTestMapped: XCTestCase {
         
         var relationships: [String : Person] = [:]
         try relationships <~ map["relationships"]
-        XCTAssert(relationships == expectedRelationships)
+        XCTAssertEqual(relationships, expectedRelationships)
         
         var optionalRelationships: [String : Person]?
         try optionalRelationships <~ map["relationships"]
-        XCTAssert(optionalRelationships! == expectedRelationships)
+        XCTAssertEqual(optionalRelationships!, expectedRelationships)
         
         var emptyDictionary: [String : Person]?
         try emptyDictionary <~ map["i_dont_exist"]
-        XCTAssert(emptyDictionary == nil)
+        XCTAssertNil(emptyDictionary)
     }
     
     func testMappableDictionaryOfArrays() throws {
@@ -240,18 +240,18 @@ class FromNodeOperatorTestMapped: XCTestCase {
         try optionalGroups <~ map["groups"]
         
         for groupsArray in [groups, try optionalGroups.unwrap()] {
-            XCTAssert(groupsArray.count == 2)
+            XCTAssertEqual(groupsArray.count, 2)
             
             let boys = try groupsArray["boys"].unwrap()
-            XCTAssert(boys ==  [joeObject, justinObject, philObject])
+            XCTAssertEqual(boys,  [joeObject, justinObject, philObject])
             
             let girls = try groupsArray["girls"].unwrap()
-            XCTAssert(girls ==  [janeObject])
+            XCTAssertEqual(girls,  [janeObject])
         }
         
         var emptyDictionaryOfArrays: [String : [Person]]?
         try emptyDictionaryOfArrays <~ map["i_dont_exist"]
-        XCTAssert(emptyDictionaryOfArrays == nil)
+        XCTAssertNil(emptyDictionaryOfArrays)
     }
     
     func testMappableSet() throws {
@@ -261,19 +261,19 @@ class FromNodeOperatorTestMapped: XCTestCase {
         try optionalPeople <~ map["duplicated_people"]
         
         for peopleSet in [people, try optionalPeople.unwrap()] {
-            XCTAssert(peopleSet.count == 2)
+            XCTAssertEqual(peopleSet.count, 2)
             XCTAssert(peopleSet.contains(joeObject))
             XCTAssert(peopleSet.contains(janeObject))
         }
         
         var singleValueToSet: Set<Person> = Set<Person>()
         try singleValueToSet <~ map["person"]
-        XCTAssert(singleValueToSet.count == 1)
+        XCTAssertEqual(singleValueToSet.count, 1)
         XCTAssert(singleValueToSet.contains(joeObject))
         
         var emptyPersons: [Person]?
         try emptyPersons <~ map["i_dont_exist"]
-        XCTAssert(emptyPersons == nil)
+        XCTAssertNil(emptyPersons)
     }
     
 }

--- a/Tests/GenomeTests/FromNodeOperatorTest.swift
+++ b/Tests/GenomeTests/FromNodeOperatorTest.swift
@@ -133,7 +133,7 @@ class FromNodeOperatorTestBasic: XCTestCase {
     func testStringsArrayOptional() throws {
         var strings: [String]? = nil
         try strings <~ map["strings"]
-        XCTAssertEqual(strings!, ["one", "two", "three"])
+        XCTAssert(strings == ["one", "two", "three"])
     }
 
     func testInt() throws {
@@ -177,7 +177,7 @@ class FromNodeOperatorTestMapped: XCTestCase {
         
         var optionalPerson: Person?
         try optionalPerson <~ map["person"]
-        XCTAssertEqual(optionalPerson!, joeObject)
+        XCTAssertEqual(optionalPerson, joeObject)
         
         var emptyPerson: Person?
         try emptyPerson <~ map["i-dont-exist"]
@@ -191,7 +191,7 @@ class FromNodeOperatorTestMapped: XCTestCase {
         
         var optionalPeople: [Person]?
         try optionalPeople <~ map["people"]
-        XCTAssertEqual(optionalPeople!,  [joeObject, janeObject])
+        XCTAssert(optionalPeople == [joeObject, janeObject])
         
         var emptyPersons: [Person]?
         try emptyPersons <~ map["i_dont_exist"]
@@ -206,8 +206,8 @@ class FromNodeOperatorTestMapped: XCTestCase {
         
         var optionalOrderedGroups: [[Person]]?
         try optionalOrderedGroups <~ map["ordered_groups"]
-        XCTAssertEqual(optionalOrderedGroups![0],  [joeObject, justinObject, philObject])
-        XCTAssertEqual(optionalOrderedGroups![1],  [janeObject])
+        XCTAssert(optionalOrderedGroups?[0] == [joeObject, justinObject, philObject])
+        XCTAssert(optionalOrderedGroups?[1] == [janeObject])
         
         var emptyOrderedGroups: [[Person]]?
         try emptyOrderedGroups <~ map["i_dont_exist"]
@@ -226,7 +226,7 @@ class FromNodeOperatorTestMapped: XCTestCase {
         
         var optionalRelationships: [String : Person]?
         try optionalRelationships <~ map["relationships"]
-        XCTAssertEqual(optionalRelationships!, expectedRelationships)
+        XCTAssert(optionalRelationships == expectedRelationships)
         
         var emptyDictionary: [String : Person]?
         try emptyDictionary <~ map["i_dont_exist"]

--- a/Tests/GenomeTests/NodeDataTypeTest.swift
+++ b/Tests/GenomeTests/NodeDataTypeTest.swift
@@ -21,38 +21,38 @@ class NodeDataTypeTest: XCTestCase {
     let integerValue: Int = 127
     lazy var integerNodeValue: Node = Node(Double(self.integerValue))
 
-    func testIntegers() {
+    func testIntegers() throws {
         
-        let int = try! Int(node: integerNodeValue)
+        let int = try Int(node: integerNodeValue)
         XCTAssert(int == integerValue)
         
-        let int8 = try! Int8(node: integerNodeValue)
+        let int8 = try Int8(node: integerNodeValue)
         XCTAssert(int8 == Int8(integerValue))
         
-        let int16 = try! Int16(node: integerNodeValue)
+        let int16 = try Int16(node: integerNodeValue)
         XCTAssert(int16 == Int16(integerValue))
         
-        let int32 = try! Int32(node: integerNodeValue)
+        let int32 = try Int32(node: integerNodeValue)
         XCTAssert(int32 == Int32(integerValue))
         
-        let int64 = try! Int64(node: integerNodeValue)
+        let int64 = try Int64(node: integerNodeValue)
         XCTAssert(int64 == Int64(integerValue))
     }
 
-    func testUnsignedIntegers() {
-        let uint = try! UInt(node: integerNodeValue)
+    func testUnsignedIntegers() throws {
+        let uint = try UInt(node: integerNodeValue)
         XCTAssert(uint == UInt(integerValue))
         
-        let uint8 = try! UInt8(node: integerNodeValue)
+        let uint8 = try UInt8(node: integerNodeValue)
         XCTAssert(uint8 == UInt8(integerValue))
         
-        let uint16 = try! UInt16(node: integerNodeValue)
+        let uint16 = try UInt16(node: integerNodeValue)
         XCTAssert(uint16 == UInt16(integerValue))
         
-        let uint32 = try! UInt32(node: integerNodeValue)
+        let uint32 = try UInt32(node: integerNodeValue)
         XCTAssert(uint32 == UInt32(integerValue))
         
-        let uint64 = try! UInt64(node: integerNodeValue)
+        let uint64 = try UInt64(node: integerNodeValue)
         XCTAssert(uint64 == UInt64(integerValue))
     }
 }

--- a/Tests/GenomeTests/NodeDataTypeTest.swift
+++ b/Tests/GenomeTests/NodeDataTypeTest.swift
@@ -24,35 +24,35 @@ class NodeDataTypeTest: XCTestCase {
     func testIntegers() throws {
         
         let int = try Int(node: integerNodeValue)
-        XCTAssert(int == integerValue)
+        XCTAssertEqual(int, integerValue)
         
         let int8 = try Int8(node: integerNodeValue)
-        XCTAssert(int8 == Int8(integerValue))
+        XCTAssertEqual(int8, Int8(integerValue))
         
         let int16 = try Int16(node: integerNodeValue)
-        XCTAssert(int16 == Int16(integerValue))
+        XCTAssertEqual(int16, Int16(integerValue))
         
         let int32 = try Int32(node: integerNodeValue)
-        XCTAssert(int32 == Int32(integerValue))
+        XCTAssertEqual(int32, Int32(integerValue))
         
         let int64 = try Int64(node: integerNodeValue)
-        XCTAssert(int64 == Int64(integerValue))
+        XCTAssertEqual(int64, Int64(integerValue))
     }
 
     func testUnsignedIntegers() throws {
         let uint = try UInt(node: integerNodeValue)
-        XCTAssert(uint == UInt(integerValue))
+        XCTAssertEqual(uint, UInt(integerValue))
         
         let uint8 = try UInt8(node: integerNodeValue)
-        XCTAssert(uint8 == UInt8(integerValue))
+        XCTAssertEqual(uint8, UInt8(integerValue))
         
         let uint16 = try UInt16(node: integerNodeValue)
-        XCTAssert(uint16 == UInt16(integerValue))
+        XCTAssertEqual(uint16, UInt16(integerValue))
         
         let uint32 = try UInt32(node: integerNodeValue)
-        XCTAssert(uint32 == UInt32(integerValue))
+        XCTAssertEqual(uint32, UInt32(integerValue))
         
         let uint64 = try UInt64(node: integerNodeValue)
-        XCTAssert(uint64 == UInt64(integerValue))
+        XCTAssertEqual(uint64, UInt64(integerValue))
     }
 }

--- a/Tests/GenomeTests/Optional+unwrap.swift
+++ b/Tests/GenomeTests/Optional+unwrap.swift
@@ -1,0 +1,18 @@
+//
+//  Optional+unwrap.swift
+//  Genome
+//
+//  Created by Tim Vermeulen on 14/05/2017.
+//
+//
+
+extension Optional {
+    enum Error: Swift.Error {
+        case missingValue
+    }
+    
+    func unwrap() throws -> Wrapped {
+        guard let value = self else { throw Error.missingValue }
+        return value
+    }
+}

--- a/Tests/GenomeTests/Optional+unwrap.swift
+++ b/Tests/GenomeTests/Optional+unwrap.swift
@@ -6,13 +6,13 @@
 //
 //
 
+enum OptionalError: Swift.Error {
+    case missingValue
+}
+
 extension Optional {
-    enum Error: Swift.Error {
-        case missingValue
-    }
-    
     func unwrap() throws -> Wrapped {
-        guard let value = self else { throw Error.missingValue }
+        guard let value = self else { throw OptionalError.missingValue }
         return value
     }
 }

--- a/Tests/GenomeTests/Overloads.swift
+++ b/Tests/GenomeTests/Overloads.swift
@@ -1,0 +1,44 @@
+//
+//  Overloads.swift
+//  Genome
+//
+//  Created by Tim Vermeulen on 14/05/2017.
+//
+//
+
+func == <T: Equatable> (lhs: [T]?, rhs: [T]?) -> Bool {
+    switch (lhs, rhs) {
+    case let (left?, right?):
+        return left == right
+    case (nil, nil):
+        return true
+    default:
+        return false
+    }
+}
+
+func == <T: Equatable> (lhs: [[T]], rhs: [[T]]) -> Bool {
+    return lhs.count == rhs.count && !zip(lhs, rhs).contains(where: !=)
+}
+
+func == <T: Equatable> (lhs: [[T]]?, rhs: [[T]]?) -> Bool {
+    switch (lhs, rhs) {
+    case let (left?, right?):
+        return left == right
+    case (nil, nil):
+        return true
+    default:
+        return false
+    }
+}
+
+func == <K, V: Equatable> (lhs: [K: V]?, rhs: [K: V]?) -> Bool {
+    switch (lhs, rhs) {
+    case let (left?, right?):
+        return left == right
+    case (nil, nil):
+        return false
+    default:
+        return true
+    }
+}

--- a/Tests/GenomeTests/PathIndexable.swift
+++ b/Tests/GenomeTests/PathIndexable.swift
@@ -23,7 +23,7 @@ class PathIndexable: XCTestCase {
         let array: Node = ["one",
                            "two",
                            "three"]
-        XCTAssert(array[1] == "two")
+        XCTAssertEqual(array[1], "two")
     }
 
     func testString() {
@@ -33,7 +33,7 @@ class PathIndexable: XCTestCase {
 
     func testStringSequenceObject() {
         let ob: Node = ["key" : ["path" : "found me!"]]
-        XCTAssert(ob["key", "path"] == "found me!")
+        XCTAssertEqual(ob["key", "path"], "found me!")
     }
 
     func testStringSequenceArray() {
@@ -42,18 +42,18 @@ class PathIndexable: XCTestCase {
                              ["a" : 2],
                              ["a" : 3]]
         let collection = obArray["a"]
-        XCTAssert(collection == [0,1,2,3])
+        XCTAssertEqual(collection, [0,1,2,3])
     }
 
     func testIntSequence() {
         let inner: Node = ["...",
                            "found me!"]
         let outer: Node = [inner]
-        XCTAssert(outer[0, 1] == "found me!")
+        XCTAssertEqual(outer[0, 1], "found me!")
     }
 
     func testMixed() {
         let mixed: Node = ["one" : ["a", "b", "c"]]
-        XCTAssert(mixed["one", 1] == "b")
+        XCTAssertEqual(mixed["one", 1], "b")
     }
 }

--- a/Tests/GenomeTests/SettableOperatorTest.swift
+++ b/Tests/GenomeTests/SettableOperatorTest.swift
@@ -37,52 +37,52 @@ class SettableOperatorTest: XCTestCase {
 
     func testBasicTypes() throws {
         let int: Int = try map.extract("int")
-        XCTAssert(int == 272)
+        XCTAssertEqual(int, 272)
         
         let optionalInt: Int? = try map.extract("int")
-        XCTAssert(optionalInt! == 272)
+        XCTAssertEqual(optionalInt!, 272)
         
         let strings: [String] = try map.extract("strings")
-        XCTAssert(strings == ["one", "two", "three"])
+        XCTAssertEqual(strings, ["one", "two", "three"])
         
         let optionalStrings: [String]? = try map.extract("strings")
-        XCTAssert(optionalStrings ?? [] == ["one", "two", "three"])
+        XCTAssertEqual(optionalStrings ?? [], ["one", "two", "three"])
         
         let stringInt: String = try map.extract("int") { (nodeValue: Int) in
                 return "\(nodeValue)"
         }
-        XCTAssert(stringInt == "272")
+        XCTAssertEqual(stringInt, "272")
         
         let emptyInt: Int? = try map.extract("i_dont_exist")
-        XCTAssert(emptyInt == nil)
+        XCTAssertNil(emptyInt)
         
         let emptyStrings: [String]? = try map.extract("i_dont_exist")
-        XCTAssert(emptyStrings == nil)
+        XCTAssertNil(emptyStrings)
     }
     
     func testMappableObject() throws {
         let person: Person = try map.extract("person")
-        XCTAssert(person == joeObject)
+        XCTAssertEqual(person, joeObject)
         
         let optionalPerson: Person? = try map.extract("person")
-        XCTAssert(optionalPerson == joeObject)
+        XCTAssertEqual(optionalPerson, joeObject)
         
         let emptyPerson: Person? = try map.extract("i_dont_exist")
-        XCTAssert(emptyPerson == nil)
+        XCTAssertNil(emptyPerson)
     }
     
     func testMappableArray() throws {
         let people: [Person] = try map.extract("people")
-        XCTAssert(people == [joeObject, janeObject])
+        XCTAssertEqual(people, [joeObject, janeObject])
         
         let optionalPeople: [Person]? = try map.extract("people")
-        XCTAssert(optionalPeople! == [joeObject, janeObject])
+        XCTAssertEqual(optionalPeople!, [joeObject, janeObject])
         
         let singleValueToArray: [Person] = try map.extract("person")
-        XCTAssert(singleValueToArray == [joeObject])
+        XCTAssertEqual(singleValueToArray, [joeObject])
         
         let emptyPersons: [Person]? = try map.extract("i_dont_exist")
-        XCTAssert(emptyPersons == nil)
+        XCTAssertNil(emptyPersons)
     }
     
     func testMappableArrayOfArrays() throws {
@@ -90,21 +90,21 @@ class SettableOperatorTest: XCTestCase {
         let optionalOrderedGroups: [[Person]]? = try map.extract("ordered_groups")
         
         for orderGroupsArray in [orderedGroups, try optionalOrderedGroups.unwrap()] {
-            XCTAssert(orderGroupsArray.count == 2)
+            XCTAssertEqual(orderGroupsArray.count, 2)
             
             let firstGroup = orderGroupsArray[0]
-            XCTAssert(firstGroup == [joeObject, justinObject, philObject])
+            XCTAssertEqual(firstGroup, [joeObject, justinObject, philObject])
             
             let secondGroup = orderGroupsArray[1]
-            XCTAssert(secondGroup == [janeObject])
+            XCTAssertEqual(secondGroup, [janeObject])
         }
         
         let arrayValueToArrayOfArrays: [[Person]] = try map.extract("people")
-        XCTAssert(arrayValueToArrayOfArrays.count == 2)
-        XCTAssert(arrayValueToArrayOfArrays.first! == [joeObject])
+        XCTAssertEqual(arrayValueToArrayOfArrays.count, 2)
+        XCTAssertEqual(arrayValueToArrayOfArrays.first!, [joeObject])
         
         let emptyArrayOfArrays: [[Person]]? = try map.extract("i_dont_exist")
-        XCTAssert(emptyArrayOfArrays == nil)
+        XCTAssertNil(emptyArrayOfArrays)
     }
     
     func testMappableDictionary() throws {
@@ -114,13 +114,13 @@ class SettableOperatorTest: XCTestCase {
         ]
         
         let relationships: [String : Person] = try map.extract("relationships")
-        XCTAssert(relationships == expectedRelationships)
+        XCTAssertEqual(relationships, expectedRelationships)
         
         let optionalRelationships: [String : Person]? = try map.extract("relationships")
-        XCTAssert(optionalRelationships! == expectedRelationships)
+        XCTAssertEqual(optionalRelationships!, expectedRelationships)
         
         let emptyDictionary: [String : Person]? = try map.extract("i_dont_exist")
-        XCTAssert(emptyDictionary == nil)
+        XCTAssertNil(emptyDictionary)
     }
     
     func testMappableDictionaryOfArrays() throws {
@@ -128,17 +128,17 @@ class SettableOperatorTest: XCTestCase {
         let optionalGroups: [String : [Person]]? = try map.extract("groups")
         
         for groupsArray in [groups, try optionalGroups.unwrap()] {
-            XCTAssert(groupsArray.count == 2)
+            XCTAssertEqual(groupsArray.count, 2)
             
             let boys = try groupsArray["boys"].unwrap()
-            XCTAssert(boys == [joeObject, justinObject, philObject])
+            XCTAssertEqual(boys, [joeObject, justinObject, philObject])
             
             let girls = try groupsArray["girls"].unwrap()
-            XCTAssert(girls == [janeObject])
+            XCTAssertEqual(girls, [janeObject])
         }
         
         let emptyDictionaryOfArrays: [String : [Person]]? = try map.extract("i_dont_exist")
-        XCTAssert(emptyDictionaryOfArrays == nil)
+        XCTAssertNil(emptyDictionaryOfArrays)
     }
     
     func testMappableSet() throws {
@@ -146,17 +146,17 @@ class SettableOperatorTest: XCTestCase {
         let optionalPeople: Set<Person>? = try map.extract("duplicated_people")
         
         for peopleSet in [people, try optionalPeople.unwrap()] {
-            XCTAssert(peopleSet.count == 2)
+            XCTAssertEqual(peopleSet.count, 2)
             XCTAssert(peopleSet.contains(joeObject))
             XCTAssert(peopleSet.contains(janeObject))
         }
         
         let singleValueToSet: Set<Person> = try map.extract("person")
-        XCTAssert(singleValueToSet.count == 1)
+        XCTAssertEqual(singleValueToSet.count, 1)
         XCTAssert(singleValueToSet.contains(joeObject))
         
         let emptyPersons: [Person]? = try map.extract("i_dont_exist")
-        XCTAssert(emptyPersons == nil)
+        XCTAssertNil(emptyPersons)
     }
 
     func testDictionaryUnableToConvert() {
@@ -186,8 +186,8 @@ class SettableOperatorTest: XCTestCase {
             let _: Bool = try map.extract("int")
             XCTFail("Incorrect type should throw error")
         } catch let NodeError.unableToConvert(node: node, expected: expected) {
-            XCTAssert(node == 272)
-            XCTAssert(expected == "Bool")
+            XCTAssertEqual(node, 272)
+            XCTAssertEqual(expected, "Bool")
         } catch {
             XCTFail("Incorrect Error: \(error) Expected: \(NodeError.unableToConvert)")
         }
@@ -230,8 +230,8 @@ class SettableOperatorTest: XCTestCase {
             }
             XCTFail("Incorrect type should throw error")
         }  catch let NodeError.unableToConvert(node: node, expected: expected) {
-            XCTAssert(node == 272)
-            XCTAssert(expected == "Bool")
+            XCTAssertEqual(node, 272)
+            XCTAssertEqual(expected, "Bool")
         } catch {
             XCTFail("Incorrect Error: \(error) Expected: \(NodeError.unableToConvert)")
         }

--- a/Tests/GenomeTests/SettableOperatorTest.swift
+++ b/Tests/GenomeTests/SettableOperatorTest.swift
@@ -89,7 +89,7 @@ class SettableOperatorTest: XCTestCase {
         let orderedGroups: [[Person]] = try map.extract("ordered_groups")
         let optionalOrderedGroups: [[Person]]? = try map.extract("ordered_groups")
         
-        for orderGroupsArray in [orderedGroups, optionalOrderedGroups!] {
+        for orderGroupsArray in [orderedGroups, try optionalOrderedGroups.unwrap()] {
             XCTAssert(orderGroupsArray.count == 2)
             
             let firstGroup = orderGroupsArray[0]
@@ -127,13 +127,13 @@ class SettableOperatorTest: XCTestCase {
         let groups: [String : [Person]] = try map.extract("groups")
         let optionalGroups: [String : [Person]]? = try map.extract("groups")
         
-        for groupsArray in [groups, optionalGroups!] {
+        for groupsArray in [groups, try optionalGroups.unwrap()] {
             XCTAssert(groupsArray.count == 2)
             
-            let boys = groupsArray["boys"]!
+            let boys = try groupsArray["boys"].unwrap()
             XCTAssert(boys == [joeObject, justinObject, philObject])
             
-            let girls = groupsArray["girls"]!
+            let girls = try groupsArray["girls"].unwrap()
             XCTAssert(girls == [janeObject])
         }
         
@@ -145,7 +145,7 @@ class SettableOperatorTest: XCTestCase {
         let people: Set<Person> = try map.extract("duplicated_people")
         let optionalPeople: Set<Person>? = try map.extract("duplicated_people")
         
-        for peopleSet in [people, optionalPeople!] {
+        for peopleSet in [people, try optionalPeople.unwrap()] {
             XCTAssert(peopleSet.count == 2)
             XCTAssert(peopleSet.contains(joeObject))
             XCTAssert(peopleSet.contains(janeObject))

--- a/Tests/GenomeTests/SettableOperatorTest.swift
+++ b/Tests/GenomeTests/SettableOperatorTest.swift
@@ -40,7 +40,7 @@ class SettableOperatorTest: XCTestCase {
         XCTAssertEqual(int, 272)
         
         let optionalInt: Int? = try map.extract("int")
-        XCTAssertEqual(optionalInt!, 272)
+        XCTAssertEqual(optionalInt, 272)
         
         let strings: [String] = try map.extract("strings")
         XCTAssertEqual(strings, ["one", "two", "three"])
@@ -76,7 +76,7 @@ class SettableOperatorTest: XCTestCase {
         XCTAssertEqual(people, [joeObject, janeObject])
         
         let optionalPeople: [Person]? = try map.extract("people")
-        XCTAssertEqual(optionalPeople!, [joeObject, janeObject])
+        XCTAssert(optionalPeople == [joeObject, janeObject])
         
         let singleValueToArray: [Person] = try map.extract("person")
         XCTAssertEqual(singleValueToArray, [joeObject])
@@ -101,7 +101,7 @@ class SettableOperatorTest: XCTestCase {
         
         let arrayValueToArrayOfArrays: [[Person]] = try map.extract("people")
         XCTAssertEqual(arrayValueToArrayOfArrays.count, 2)
-        XCTAssertEqual(arrayValueToArrayOfArrays.first!, [joeObject])
+        XCTAssert(arrayValueToArrayOfArrays.first == [joeObject])
         
         let emptyArrayOfArrays: [[Person]]? = try map.extract("i_dont_exist")
         XCTAssertNil(emptyArrayOfArrays)
@@ -117,7 +117,7 @@ class SettableOperatorTest: XCTestCase {
         XCTAssertEqual(relationships, expectedRelationships)
         
         let optionalRelationships: [String : Person]? = try map.extract("relationships")
-        XCTAssertEqual(optionalRelationships!, expectedRelationships)
+        XCTAssert(optionalRelationships == expectedRelationships)
         
         let emptyDictionary: [String : Person]? = try map.extract("i_dont_exist")
         XCTAssertNil(emptyDictionary)

--- a/Tests/GenomeTests/ToNodeOperatorTest.swift
+++ b/Tests/GenomeTests/ToNodeOperatorTest.swift
@@ -171,20 +171,20 @@ class ToNodeOperatorTest: XCTestCase {
         // Basic type
         let name = try node["name"].unwrap().string.unwrap()
         XCTAssertEqual(name, "Good Business", "name is \(name) expected: Good Business")
-        let foundedYear = node["foundedYear"]!.int
-        XCTAssertEqual(foundedYear, 1987, "foundedYear is \(foundedYear) expected: 1987")
+        let foundedYear = try node["foundedYear"].unwrap().int
+        XCTAssertEqual(foundedYear, 1987)
         
         // Basic type array
         let locations = try node["locations"].unwrap()
         XCTAssertEqual(locations, self.locations, "locations is \(locations) expected: \(self.locations)")
         let locationsOptional = node["locationsOptional"]
-        XCTAssertEqual(locationsOptional, self.locations, "locationsOptional is \(locationsOptional) expected: \(self.locations)")
+        XCTAssertEqual(locationsOptional, self.locations)
         
         // Mappable
         let owner = try node["owner"].unwrap()
         XCTAssertEqual(owner, self.owner, "owner is \(owner) expected: \(self.owner)")
         let ownerOptional = node["ownerOptional"]
-        XCTAssertEqual(ownerOptional, self.owner, "ownerOptional is \(ownerOptional) expected: \(self.owner)")
+        XCTAssertEqual(ownerOptional, self.owner)
         
         // Mappable array
         let employees = try node["employees"].unwrap()
@@ -194,52 +194,42 @@ class ToNodeOperatorTest: XCTestCase {
         
         // Mappable array of arrays
         let employeesArray = try node["employeesArray"].unwrap()
-        XCTAssertEqual(employeesArray[0], self.employeesArray[0], "employeesArray[0] is \(employeesArray[0]) expected: \(self.employeesArray[0])")
-        XCTAssertEqual(employeesArray[1], self.employeesArray[1], "employeesArray[1] is \(employeesArray[1]) expected: \(self.employeesArray[1])")
+        XCTAssertEqual(employeesArray[0], self.employeesArray[0])
+        XCTAssertEqual(employeesArray[1], self.employeesArray[1])
         let employeesOptionalArray = node["employeesOptionalArray"]
-        XCTAssertEqual(employeesOptionalArray![0]!, self.employeesArray[0], "employeesOptionalArray[0] is \(employeesOptionalArray?[0]) expected: \(self.employeesArray[0])")
-        XCTAssertEqual(employeesOptionalArray![1]!, self.employeesArray[1], "employeesOptionalArray[1] is \(employeesOptionalArray?[1]) expected: \(self.employeesArray[1])")
+        XCTAssertEqual(employeesOptionalArray?[0], self.employeesArray[0])
+        XCTAssertEqual(employeesOptionalArray?[1], self.employeesArray[1])
         
         // Mappable dictionary
         let employeesDictionary = try node["employeesDictionary"].unwrap()
-        XCTAssertEqual(employeesDictionary["0"]!, self.employeesDictionary["0"]!,
-                  "employeesDictionary[\"0\"] is \(employeesDictionary["0"]!) expected: \(self.employeesDictionary["0"]!)")
-        XCTAssertEqual(employeesDictionary["1"]!, self.employeesDictionary["1"]!,
-                  "employeesDictionary[\"1\"] is \(employeesDictionary["1"]!) expected: \(self.employeesDictionary[""]!)")
+        XCTAssertEqual(employeesDictionary["0"], self.employeesDictionary["0"])
+        XCTAssertEqual(employeesDictionary["1"], self.employeesDictionary["1"])
         let employeesOptionalDictionary = node["employeesOptionalDictionary"]
-        XCTAssertEqual(employeesOptionalDictionary!["0"]!, self.employeesDictionary["0"]!,
-                  "employeesOptionalDictionary[\"0\"] is \(employeesOptionalDictionary?["0"]!) expected: \(self.employeesDictionary["0"]!)")
-        XCTAssertEqual(employeesOptionalDictionary!["1"]!, self.employeesDictionary["1"]!,
-                  "employeesOptionalDictionary[\"1\"] is \(employeesOptionalDictionary?["1"]!) expected: \(self.employeesDictionary["1"]!)")
+        XCTAssertEqual(employeesOptionalDictionary?["0"], self.employeesDictionary["0"])
+        XCTAssertEqual(employeesOptionalDictionary?["1"], self.employeesDictionary["1"])
         
         // Mappable dictionary array
         let employeesDictionaryArray = try node["employeesDictionaryArray"].unwrap()
-        XCTAssertEqual(employeesDictionaryArray["0"]!, self.employeesDictionaryArray["0"]!,
-                  "employeesDictionaryArray[\"0\"] is \(employeesDictionaryArray["0"]!) expected: \(self.employeesDictionaryArray["0"]!)")
-        XCTAssertEqual(employeesDictionaryArray["1"]!, self.employeesDictionaryArray["1"]!,
-                  "employeesDictionaryArray[\"1\"] is \(employeesDictionaryArray["1"]!) expected: \(self.employeesDictionaryArray["1"]!)")
+        XCTAssertEqual(employeesDictionaryArray["0"], self.employeesDictionaryArray["0"])
+        XCTAssertEqual(employeesDictionaryArray["1"], self.employeesDictionaryArray["1"])
         let employeesOptionalDictionaryArray = node["employeesOptionalDictionaryArray"]
-        XCTAssertEqual(employeesOptionalDictionaryArray!["0"]!, self.employeesDictionaryArray["0"]!,
-                  "employeesOptionalDictionaryArray[\"0\"] is \(employeesOptionalDictionaryArray?["0"]!) expected: \(self.employeesDictionaryArray["0"]!)")
-        XCTAssertEqual(employeesOptionalDictionaryArray!["1"]!, self.employeesDictionaryArray["1"]!,
-                  "employeesOptionalDictionaryArray[\"1\"] is \(employeesOptionalDictionaryArray?["1"]!) expected: \(self.employeesDictionaryArray["1"]!)")
+        XCTAssertEqual(employeesOptionalDictionaryArray?["0"], self.employeesDictionaryArray["0"])
+        XCTAssertEqual(employeesOptionalDictionaryArray?["1"], self.employeesDictionaryArray["1"])
         
         // Mappable set
         // Temporarily commented out on linux because it's reordering array
         #if Xcode
         let employeesSet = try node["employeesSet"].unwrap()
-        XCTAssertEqual(employeesSet, self.employeesSet,
-                  "employeesSet is \(employeesSet) expected: \(self.employeesSet)")
+        XCTAssertEqual(employeesSet, self.employeesSet)
         let employeesOptionalSet = node["employeesOptionalSet"]
-        XCTAssertEqual(employeesOptionalSet, self.employeesSet,
-                  "employeesOptionalSet is \(employeesOptionalSet) expected: \(self.employeesSet)")
+        XCTAssertEqual(employeesOptionalSet, self.employeesSet)
         #endif
 
         // Nil
         let optionalNil = node["optionalNil"]
         XCTAssertNil(optionalNil)
         let optionalNotNil = node["optionalNotNil"]
-        XCTAssertTrue(optionalNotNil != nil, "optionalNotNil is \(optionalNotNil) expected: \(node["optionalNotNil"])")
+        XCTAssertNotNil(optionalNotNil)
     }
     
 }

--- a/Tests/GenomeTests/ToNodeOperatorTest.swift
+++ b/Tests/GenomeTests/ToNodeOperatorTest.swift
@@ -58,32 +58,32 @@ class ToNodeOperatorTest: XCTestCase {
         var optionalNil: String?
         var optionalNotNil: String? = "not nil"
         
-        init(map: Map) {
-            name = try! map.extract("name")
-            foundedYear = try! map.extract("founded_in")
+        init(map: Map) throws {
+            name = try map.extract("name")
+            foundedYear = try map.extract("founded_in")
             
-            locations = try! map.extract("locations")
-            locationsOptional = try! map.extract("locations")
+            locations = try map.extract("locations")
+            locationsOptional = try map.extract("locations")
             
-            let ownerrr: Employee = try! map.extract("owner")
+            let ownerrr: Employee = try map.extract("owner")
             print("Ownerer: \(ownerrr)")
-            owner = try! map.extract("owner")
-            ownerOptional = try! map.extract("owner")
+            owner = try map.extract("owner")
+            ownerOptional = try map.extract("owner")
             
-            employees = try! map.extract("employees")
-            employeesOptional = try! map.extract("employees")
+            employees = try map.extract("employees")
+            employeesOptional = try map.extract("employees")
             
-            employeesArray = try! map.extract("employeesArray")
-            employeesOptionalArray = try! map.extract("employeesArray")
+            employeesArray = try map.extract("employeesArray")
+            employeesOptionalArray = try map.extract("employeesArray")
             
-            employeesDictionary = try! map.extract("employeesDictionary")
-            employeesOptionalDictionary = try! map.extract("employeesDictionary")
+            employeesDictionary = try map.extract("employeesDictionary")
+            employeesOptionalDictionary = try map.extract("employeesDictionary")
             
-            employeesDictionaryArray = try! map.extract("employeesDictionaryArray")
-            employeesOptionalDictionaryArray = try! map.extract("employeesDictionaryArray")
+            employeesDictionaryArray = try map.extract("employeesDictionaryArray")
+            employeesOptionalDictionaryArray = try map.extract("employeesDictionaryArray")
             
-            employeesSet = try! map.extract("employees")
-            employeesOptionalSet = try! map.extract("employees")
+            employeesSet = try map.extract("employees")
+            employeesOptionalSet = try map.extract("employees")
         }
         
         func sequence(_ map: Map) throws -> Void {
@@ -165,10 +165,9 @@ class ToNodeOperatorTest: XCTestCase {
         "employeesSet" : self.employeesSet
     ]
     
-    lazy var goodBusiness: Business = try! Business(node: self.businessNode)
-    
-    func testMapping() {
-        let node = try! goodBusiness.makeNode()
+    func testMapping() throws {
+        let goodBusiness = try Business(node: businessNode)
+        let node = try goodBusiness.makeNode()
         // Basic type
         let name = node["name"]!.string!
         XCTAssert(name == "Good Business", "name is \(name) expected: Good Business")

--- a/Tests/GenomeTests/ToNodeOperatorTest.swift
+++ b/Tests/GenomeTests/ToNodeOperatorTest.swift
@@ -169,31 +169,31 @@ class ToNodeOperatorTest: XCTestCase {
         let goodBusiness = try Business(node: businessNode)
         let node = try goodBusiness.makeNode()
         // Basic type
-        let name = node["name"]!.string!
+        let name = try node["name"].unwrap().string.unwrap()
         XCTAssert(name == "Good Business", "name is \(name) expected: Good Business")
         let foundedYear = node["foundedYear"]!.int
         XCTAssert(foundedYear == 1987, "foundedYear is \(foundedYear) expected: 1987")
         
         // Basic type array
-        let locations = node["locations"]!
+        let locations = try node["locations"].unwrap()
         XCTAssert(locations == self.locations, "locations is \(locations) expected: \(self.locations)")
         let locationsOptional = node["locationsOptional"]
         XCTAssert(locationsOptional == self.locations, "locationsOptional is \(locationsOptional) expected: \(self.locations)")
         
         // Mappable
-        let owner = node["owner"]!
+        let owner = try node["owner"].unwrap()
         XCTAssert(owner == self.owner, "owner is \(owner) expected: \(self.owner)")
         let ownerOptional = node["ownerOptional"]
         XCTAssert(ownerOptional == self.owner, "ownerOptional is \(ownerOptional) expected: \(self.owner)")
         
         // Mappable array
-        let employees = node["employees"]!
+        let employees = try node["employees"].unwrap()
         XCTAssert(employees == self.employees, "employees is \(employees) expected: \(self.employees)")
         let employeesOptional = node["employeesOptional"]
         XCTAssert(employeesOptional == self.employees, "employeesOptional is \(employees) expected: \(self.employees)")
         
         // Mappable array of arrays
-        let employeesArray = node["employeesArray"]!
+        let employeesArray = try node["employeesArray"].unwrap()
         XCTAssert(employeesArray[0] == self.employeesArray[0], "employeesArray[0] is \(employeesArray[0]) expected: \(self.employeesArray[0])")
         XCTAssert(employeesArray[1] == self.employeesArray[1], "employeesArray[1] is \(employeesArray[1]) expected: \(self.employeesArray[1])")
         let employeesOptionalArray = node["employeesOptionalArray"]
@@ -201,7 +201,7 @@ class ToNodeOperatorTest: XCTestCase {
         XCTAssert(employeesOptionalArray![1]! == self.employeesArray[1], "employeesOptionalArray[1] is \(employeesOptionalArray?[1]) expected: \(self.employeesArray[1])")
         
         // Mappable dictionary
-        let employeesDictionary = node["employeesDictionary"]!
+        let employeesDictionary = try node["employeesDictionary"].unwrap()
         XCTAssert(employeesDictionary["0"]! == self.employeesDictionary["0"]!,
                   "employeesDictionary[\"0\"] is \(employeesDictionary["0"]!) expected: \(self.employeesDictionary["0"]!)")
         XCTAssert(employeesDictionary["1"]! == self.employeesDictionary["1"]!,
@@ -213,7 +213,7 @@ class ToNodeOperatorTest: XCTestCase {
                   "employeesOptionalDictionary[\"1\"] is \(employeesOptionalDictionary?["1"]!) expected: \(self.employeesDictionary["1"]!)")
         
         // Mappable dictionary array
-        let employeesDictionaryArray = node["employeesDictionaryArray"]!
+        let employeesDictionaryArray = try node["employeesDictionaryArray"].unwrap()
         XCTAssert(employeesDictionaryArray["0"]! == self.employeesDictionaryArray["0"]!,
                   "employeesDictionaryArray[\"0\"] is \(employeesDictionaryArray["0"]!) expected: \(self.employeesDictionaryArray["0"]!)")
         XCTAssert(employeesDictionaryArray["1"]! == self.employeesDictionaryArray["1"]!,
@@ -227,7 +227,7 @@ class ToNodeOperatorTest: XCTestCase {
         // Mappable set
         // Temporarily commented out on linux because it's reordering array
         #if Xcode
-        let employeesSet = node["employeesSet"]!
+        let employeesSet = try node["employeesSet"].unwrap()
         XCTAssert(employeesSet == self.employeesSet,
                   "employeesSet is \(employeesSet) expected: \(self.employeesSet)")
         let employeesOptionalSet = node["employeesOptionalSet"]

--- a/Tests/GenomeTests/ToNodeOperatorTest.swift
+++ b/Tests/GenomeTests/ToNodeOperatorTest.swift
@@ -170,74 +170,74 @@ class ToNodeOperatorTest: XCTestCase {
         let node = try goodBusiness.makeNode()
         // Basic type
         let name = try node["name"].unwrap().string.unwrap()
-        XCTAssert(name == "Good Business", "name is \(name) expected: Good Business")
+        XCTAssertEqual(name, "Good Business", "name is \(name) expected: Good Business")
         let foundedYear = node["foundedYear"]!.int
-        XCTAssert(foundedYear == 1987, "foundedYear is \(foundedYear) expected: 1987")
+        XCTAssertEqual(foundedYear, 1987, "foundedYear is \(foundedYear) expected: 1987")
         
         // Basic type array
         let locations = try node["locations"].unwrap()
-        XCTAssert(locations == self.locations, "locations is \(locations) expected: \(self.locations)")
+        XCTAssertEqual(locations, self.locations, "locations is \(locations) expected: \(self.locations)")
         let locationsOptional = node["locationsOptional"]
-        XCTAssert(locationsOptional == self.locations, "locationsOptional is \(locationsOptional) expected: \(self.locations)")
+        XCTAssertEqual(locationsOptional, self.locations, "locationsOptional is \(locationsOptional) expected: \(self.locations)")
         
         // Mappable
         let owner = try node["owner"].unwrap()
-        XCTAssert(owner == self.owner, "owner is \(owner) expected: \(self.owner)")
+        XCTAssertEqual(owner, self.owner, "owner is \(owner) expected: \(self.owner)")
         let ownerOptional = node["ownerOptional"]
-        XCTAssert(ownerOptional == self.owner, "ownerOptional is \(ownerOptional) expected: \(self.owner)")
+        XCTAssertEqual(ownerOptional, self.owner, "ownerOptional is \(ownerOptional) expected: \(self.owner)")
         
         // Mappable array
         let employees = try node["employees"].unwrap()
-        XCTAssert(employees == self.employees, "employees is \(employees) expected: \(self.employees)")
+        XCTAssertEqual(employees, self.employees, "employees is \(employees) expected: \(self.employees)")
         let employeesOptional = node["employeesOptional"]
-        XCTAssert(employeesOptional == self.employees, "employeesOptional is \(employees) expected: \(self.employees)")
+        XCTAssertEqual(employeesOptional, self.employees, "employeesOptional is \(employees) expected: \(self.employees)")
         
         // Mappable array of arrays
         let employeesArray = try node["employeesArray"].unwrap()
-        XCTAssert(employeesArray[0] == self.employeesArray[0], "employeesArray[0] is \(employeesArray[0]) expected: \(self.employeesArray[0])")
-        XCTAssert(employeesArray[1] == self.employeesArray[1], "employeesArray[1] is \(employeesArray[1]) expected: \(self.employeesArray[1])")
+        XCTAssertEqual(employeesArray[0], self.employeesArray[0], "employeesArray[0] is \(employeesArray[0]) expected: \(self.employeesArray[0])")
+        XCTAssertEqual(employeesArray[1], self.employeesArray[1], "employeesArray[1] is \(employeesArray[1]) expected: \(self.employeesArray[1])")
         let employeesOptionalArray = node["employeesOptionalArray"]
-        XCTAssert(employeesOptionalArray![0]! == self.employeesArray[0], "employeesOptionalArray[0] is \(employeesOptionalArray?[0]) expected: \(self.employeesArray[0])")
-        XCTAssert(employeesOptionalArray![1]! == self.employeesArray[1], "employeesOptionalArray[1] is \(employeesOptionalArray?[1]) expected: \(self.employeesArray[1])")
+        XCTAssertEqual(employeesOptionalArray![0]!, self.employeesArray[0], "employeesOptionalArray[0] is \(employeesOptionalArray?[0]) expected: \(self.employeesArray[0])")
+        XCTAssertEqual(employeesOptionalArray![1]!, self.employeesArray[1], "employeesOptionalArray[1] is \(employeesOptionalArray?[1]) expected: \(self.employeesArray[1])")
         
         // Mappable dictionary
         let employeesDictionary = try node["employeesDictionary"].unwrap()
-        XCTAssert(employeesDictionary["0"]! == self.employeesDictionary["0"]!,
+        XCTAssertEqual(employeesDictionary["0"]!, self.employeesDictionary["0"]!,
                   "employeesDictionary[\"0\"] is \(employeesDictionary["0"]!) expected: \(self.employeesDictionary["0"]!)")
-        XCTAssert(employeesDictionary["1"]! == self.employeesDictionary["1"]!,
+        XCTAssertEqual(employeesDictionary["1"]!, self.employeesDictionary["1"]!,
                   "employeesDictionary[\"1\"] is \(employeesDictionary["1"]!) expected: \(self.employeesDictionary[""]!)")
         let employeesOptionalDictionary = node["employeesOptionalDictionary"]
-        XCTAssert(employeesOptionalDictionary!["0"]! == self.employeesDictionary["0"]!,
+        XCTAssertEqual(employeesOptionalDictionary!["0"]!, self.employeesDictionary["0"]!,
                   "employeesOptionalDictionary[\"0\"] is \(employeesOptionalDictionary?["0"]!) expected: \(self.employeesDictionary["0"]!)")
-        XCTAssert(employeesOptionalDictionary!["1"]! == self.employeesDictionary["1"]!,
+        XCTAssertEqual(employeesOptionalDictionary!["1"]!, self.employeesDictionary["1"]!,
                   "employeesOptionalDictionary[\"1\"] is \(employeesOptionalDictionary?["1"]!) expected: \(self.employeesDictionary["1"]!)")
         
         // Mappable dictionary array
         let employeesDictionaryArray = try node["employeesDictionaryArray"].unwrap()
-        XCTAssert(employeesDictionaryArray["0"]! == self.employeesDictionaryArray["0"]!,
+        XCTAssertEqual(employeesDictionaryArray["0"]!, self.employeesDictionaryArray["0"]!,
                   "employeesDictionaryArray[\"0\"] is \(employeesDictionaryArray["0"]!) expected: \(self.employeesDictionaryArray["0"]!)")
-        XCTAssert(employeesDictionaryArray["1"]! == self.employeesDictionaryArray["1"]!,
+        XCTAssertEqual(employeesDictionaryArray["1"]!, self.employeesDictionaryArray["1"]!,
                   "employeesDictionaryArray[\"1\"] is \(employeesDictionaryArray["1"]!) expected: \(self.employeesDictionaryArray["1"]!)")
         let employeesOptionalDictionaryArray = node["employeesOptionalDictionaryArray"]
-        XCTAssert(employeesOptionalDictionaryArray!["0"]! == self.employeesDictionaryArray["0"]!,
+        XCTAssertEqual(employeesOptionalDictionaryArray!["0"]!, self.employeesDictionaryArray["0"]!,
                   "employeesOptionalDictionaryArray[\"0\"] is \(employeesOptionalDictionaryArray?["0"]!) expected: \(self.employeesDictionaryArray["0"]!)")
-        XCTAssert(employeesOptionalDictionaryArray!["1"]! == self.employeesDictionaryArray["1"]!,
+        XCTAssertEqual(employeesOptionalDictionaryArray!["1"]!, self.employeesDictionaryArray["1"]!,
                   "employeesOptionalDictionaryArray[\"1\"] is \(employeesOptionalDictionaryArray?["1"]!) expected: \(self.employeesDictionaryArray["1"]!)")
         
         // Mappable set
         // Temporarily commented out on linux because it's reordering array
         #if Xcode
         let employeesSet = try node["employeesSet"].unwrap()
-        XCTAssert(employeesSet == self.employeesSet,
+        XCTAssertEqual(employeesSet, self.employeesSet,
                   "employeesSet is \(employeesSet) expected: \(self.employeesSet)")
         let employeesOptionalSet = node["employeesOptionalSet"]
-        XCTAssert(employeesOptionalSet == self.employeesSet,
+        XCTAssertEqual(employeesOptionalSet, self.employeesSet,
                   "employeesOptionalSet is \(employeesOptionalSet) expected: \(self.employeesSet)")
         #endif
 
         // Nil
         let optionalNil = node["optionalNil"]
-        XCTAssertTrue(optionalNil == nil, "optionalNil is \(optionalNil) expected: nil")
+        XCTAssertNil(optionalNil)
         let optionalNotNil = node["optionalNotNil"]
         XCTAssertTrue(optionalNotNil != nil, "optionalNotNil is \(optionalNotNil) expected: \(node["optionalNotNil"])")
     }

--- a/Tests/GenomeTests/TransformTests.swift
+++ b/Tests/GenomeTests/TransformTests.swift
@@ -22,8 +22,7 @@ class TransformTest: XCTestCase {
     func testTransform() throws {
         let map = Map(node: testNode)
         var settableString: String? = nil
-        try settableString <~ map["hello"]
-            .transformFromNode { self.stringToString(input: $0) }
+        try settableString <~ map["hello"].transformFromNode { self.stringToString(input: $0) }
         XCTAssertEqual(settableString, "modified: world")
         
         let nonOptionalString = ""
@@ -35,6 +34,6 @@ class TransformTest: XCTestCase {
     }
 
     func optStringToString(input: String?) -> String {
-        return "modified: \(input)"
+        return "modified: \(input as Any)"
     }
 }

--- a/Tests/GenomeTests/TransformTests.swift
+++ b/Tests/GenomeTests/TransformTests.swift
@@ -24,7 +24,7 @@ class TransformTest: XCTestCase {
         var settableString: String? = nil
         try settableString <~ map["hello"]
             .transformFromNode { self.stringToString(input: $0) }
-        XCTAssert(settableString == "modified: world")
+        XCTAssertEqual(settableString, "modified: world")
         
         let nonOptionalString = ""
         try nonOptionalString ~> map["test"].transformToNode(with: optStringToString)

--- a/Tests/GenomeTests/TransformTests.swift
+++ b/Tests/GenomeTests/TransformTests.swift
@@ -19,15 +19,15 @@ class TransformTest: XCTestCase {
         "hello" : "world"
     ]
     
-    func testTransform() {
+    func testTransform() throws {
         let map = Map(node: testNode)
         var settableString: String? = nil
-        try! settableString <~ map["hello"]
+        try settableString <~ map["hello"]
             .transformFromNode { self.stringToString(input: $0) }
         XCTAssert(settableString == "modified: world")
         
         let nonOptionalString = ""
-        try! nonOptionalString ~> map["test"].transformToNode(with: optStringToString)
+        try nonOptionalString ~> map["test"].transformToNode(with: optStringToString)
     }
     
     func stringToString(input: String) -> String {


### PR DESCRIPTION
Replaces a lot of force unwraps by optional unwraps and throwing errors. Also replaces most instances of `XCTAssert` by more specific assertion functions.