### PR TITLE
Add missed CURRENT_PROJECT_VERSION, DYLIB_CURRENT_VERSION

### DIFF
--- a/Genome.xcodeproj/project.pbxproj
+++ b/Genome.xcodeproj/project.pbxproj
@@ -1123,6 +1123,8 @@
          buildSettings = {
             COMBINE_HIDPI_IMAGES = "YES";
             COPY_PHASE_STRIP = "NO";
+            CURRENT_PROJECT_VERSION = 1; 
+            DYLIB_CURRENT_VERSION = 1; 
             DEBUG_INFORMATION_FORMAT = "dwarf";
             DYLIB_INSTALL_NAME_BASE = "@rpath";
             ENABLE_NS_ASSERTIONS = "YES";
@@ -1211,6 +1213,8 @@
          buildSettings = {
             COMBINE_HIDPI_IMAGES = "YES";
             COPY_PHASE_STRIP = "YES";
+            CURRENT_PROJECT_VERSION = 1; 
+            DYLIB_CURRENT_VERSION = 1; 
             DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
             DYLIB_INSTALL_NAME_BASE = "@rpath";
             GCC_OPTIMIZATION_LEVEL = "s";


### PR DESCRIPTION
It adds missed project settings such as `CURRENT_PROJECT_VERSION` and `DYLIB_CURRENT_VERSION` to avoid validation errors during applications submitting to AppStore.